### PR TITLE
feat: replace Internal Server Error responses with user-friendly no-d…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -473,4 +473,4 @@ venv
 portal/libs/middleware/authorizationImpl.js
 portal/libs/middleware/authorizationImpl.test.js
 
-scripts/account_mappings.yaml
+account_mappings.yaml

--- a/portal/routes/compliance/autoscaling.js
+++ b/portal/routes/compliance/autoscaling.js
@@ -41,7 +41,12 @@ router.get('/dimensions', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "Auto Scaling", href: "/compliance/autoscaling" }],
+            policy_title: "Auto Scaling Group Dimensions",
+            currentSection: "compliance",
+            currentPath: "/compliance/autoscaling/dimensions"
+        });
     }
 });
 
@@ -112,7 +117,16 @@ router.get('/dimensions/details', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs,
+                { text: "Auto Scaling", href: "/compliance/autoscaling" },
+                { text: "Dimensions", href: "/compliance/autoscaling/dimensions" },
+                { text: `${team || 'Details'} - ${min || 'N/A'}/${max || 'N/A'}/${desired || 'N/A'}`, href: "#" }
+            ],
+            policy_title: `Auto Scaling Groups${team ? ` (${min}/${max}/${desired}) - ${team} Team` : ' - Details'}`,
+            currentSection: "compliance",
+            currentPath: "/compliance/autoscaling/dimensions/details"
+        });
     }
 });
 
@@ -145,7 +159,12 @@ router.get('/empty', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "Auto Scaling", href: "/compliance/autoscaling" }],
+            policy_title: "Auto Scaling Groups with No Instances",
+            currentSection: "compliance",
+            currentPath: "/compliance/autoscaling/empty"
+        });
     }
 });
 

--- a/portal/routes/compliance/database.js
+++ b/portal/routes/compliance/database.js
@@ -9,7 +9,12 @@ router.get('/', async (req, res) => {
         const latestDoc = await dbQueries.getLatestRdsDate(req);
 
         if (!latestDoc) {
-            throw new Error("No data found in rds collection");
+            return res.render('errors/no-data.njk', {
+                breadcrumbs: [...complianceBreadcrumbs, { text: "Database", href: "/compliance/database" }],
+                policy_title: "Database Engines and Versions",
+                currentSection: "compliance",
+                currentPath: "/compliance/database"
+            });
         }
 
         const { year: latestYear, month: latestMonth, day: latestDay } = latestDoc;
@@ -33,7 +38,12 @@ router.get('/', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        return res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "Database", href: "/compliance/database" }],
+            policy_title: "Database Engines and Versions",
+            currentSection: "compliance",
+            currentPath: "/compliance/database"
+        });
     }
 });
 
@@ -46,7 +56,15 @@ router.get('/details', async (req, res) => {
         const latestDoc = await dbQueries.getLatestRdsDate(req);
 
         if (!latestDoc) {
-            throw new Error("No data found in rds collection");
+            return res.render('errors/no-data.njk', {
+                breadcrumbs: [...complianceBreadcrumbs,
+                    { text: "Database", href: "/compliance/database" },
+                    { text: `${team} - ${engine} ${version}`, href: "#" }
+                ],
+                policy_title: `${engine} ${version} Instances - ${team} Team`,
+                currentSection: "compliance",
+                currentPath: "/compliance/database/details"
+            });
         }
 
         const { year: latestYear, month: latestMonth, day: latestDay } = latestDoc;
@@ -94,7 +112,15 @@ router.get('/details', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        return res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs,
+                { text: "Database", href: "/compliance/database" },
+                { text: "Database Details", href: "#" }
+            ],
+            policy_title: "Database Details",
+            currentSection: "compliance",
+            currentPath: "/compliance/database/details"
+        });
     }
 });
 

--- a/portal/routes/compliance/kms.js
+++ b/portal/routes/compliance/kms.js
@@ -33,7 +33,12 @@ router.get('/', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "KMS Keys", href: "/compliance/kms" }],
+            policy_title: "KMS Key Ages",
+            currentSection: "compliance",
+            currentPath: "/compliance/kms"
+        });
     }
 });
 
@@ -107,7 +112,15 @@ router.get('/details', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs,
+                { text: "KMS Keys", href: "/compliance/kms" },
+                { text: "KMS Key Details", href: "#" }
+            ],
+            policy_title: "KMS Key Details",
+            currentSection: "compliance",
+            currentPath: "/compliance/kms/details"
+        });
     }
 });
 

--- a/portal/routes/compliance/loadbalancers.js
+++ b/portal/routes/compliance/loadbalancers.js
@@ -67,7 +67,12 @@ router.get('/tls', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
+            policy_title: "Load Balancer TLS Configurations",
+            currentSection: "compliance",
+            currentPath: "/compliance/loadbalancers/tls"
+        });
     }
 });
 
@@ -127,7 +132,15 @@ router.get('/details', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs,
+                { text: "Load Balancers", href: "/compliance/loadbalancers" },
+                { text: `${team} - ${tlsVersion}`, href: "#" }
+            ],
+            policy_title: `Load Balancers with ${tlsVersion} - ${team} Team`,
+            currentSection: "compliance",
+            currentPath: "/compliance/loadbalancers/details"
+        });
     }
 });
 
@@ -169,7 +182,12 @@ router.get('/types', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
+            policy_title: "Load Balancer Types by Team",
+            currentSection: "compliance",
+            currentPath: "/compliance/loadbalancers/types"
+        });
     }
 });
 
@@ -240,7 +258,16 @@ router.get('/types/details', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs,
+                { text: "Load Balancers", href: "/compliance/loadbalancers" },
+                { text: "Types", href: "/compliance/loadbalancers/types" },
+                { text: `${team} - ${displayType}`, href: "#" }
+            ],
+            policy_title: `${displayType} Load Balancers - ${team} Team`,
+            currentSection: "compliance",
+            currentPath: "/compliance/loadbalancers/types/details"
+        });
     }
 });
 

--- a/portal/routes/compliance/tagging.js
+++ b/portal/routes/compliance/tagging.js
@@ -60,7 +60,12 @@ router.get('/teams', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs, { text: "Tagging", href: "/compliance/tagging" }],
+            policy_title: "Tagging Compliance by Team",
+            currentSection: "compliance",
+            currentPath: "/compliance/tagging/teams"
+        });
     }
 });
 
@@ -128,7 +133,16 @@ router.get('/details', async (req, res) => {
         });
     } catch (err) {
         console.error(err);
-        res.status(500).send("Internal Server Error");
+        res.render('errors/no-data.njk', {
+            breadcrumbs: [...complianceBreadcrumbs,
+                { text: "Tagging", href: "/compliance/tagging" },
+                { text: "Teams", href: "/compliance/tagging/teams" },
+                { text: `${team || 'Team'} - ${resourceType || 'Resource'} - ${tag || 'Tag'}`, href: "#" }
+            ],
+            policy_title: `Missing ${tag || 'Tag'} Tags - ${team || 'Team'} Team`,
+            currentSection: "compliance",
+            currentPath: "/compliance/tagging/details"
+        });
     }
 });
 

--- a/portal/views/errors/no-data.njk
+++ b/portal/views/errors/no-data.njk
@@ -1,0 +1,49 @@
+{% extends "../template.njk" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        {% if breadcrumbs %}
+            {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+            {{ govukBreadcrumbs({
+                items: breadcrumbs
+            }) }}
+        {% endif %}
+
+        <h1 class="govuk-heading-l">{{ policy_title or "No Data Available" }}</h1>
+
+        {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+        {{ govukWarningText({
+            text: "There is currently no data available for this report.",
+            iconFallbackText: "Warning"
+        }) }}
+
+        <p class="govuk-body">This could be because:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>No AWS resources have been scanned yet</li>
+            <li>The data collection process has not completed</li>
+            <li>There are no resources matching the selected criteria</li>
+            <li>The data may still be processing</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">What you can do</h2>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>Check back later once the data collection has completed</li>
+            <li>Verify that AWS resources exist in your accounts</li>
+            <li>Contact your administrator if this problem persists</li>
+        </ul>
+
+        <p class="govuk-body">
+            <a href="/" class="govuk-link">Return to overview</a>
+        </p>
+
+        {% if currentSection == "compliance" %}
+        <p class="govuk-body">
+            <a href="/compliance" class="govuk-link">View other compliance reports</a>
+        </p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/portal/views/overview.njk
+++ b/portal/views/overview.njk
@@ -11,7 +11,7 @@
             Welcome to the Cloud Advice Dashboard. This application provides insights into your cloud infrastructure compliance and policy management.
         </p>
 
-        {% if dashboardMetrics %}
+        {% if dashboardMetrics and dashboardMetrics.metrics and not dashboardMetrics.error %}
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
               <h2 class="govuk-heading-l">Compliance Overview</h2>
@@ -125,13 +125,40 @@
           
           <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
         {% else %}
-          <div class="govuk-warning-text">
-            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-            <strong class="govuk-warning-text__text">
-              <span class="govuk-warning-text__assistive">Warning</span>
-              Dashboard metrics are currently unavailable. Please check back later.
-            </strong>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <h2 class="govuk-heading-l">Dashboard Data Unavailable</h2>
+
+              {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+              {{ govukWarningText({
+                text: "There is currently no dashboard data available.",
+                iconFallbackText: "Warning"
+              }) }}
+
+              <p class="govuk-body">This could be because:</p>
+
+              <ul class="govuk-list govuk-list--bullet">
+                <li>No AWS resources have been scanned yet</li>
+                <li>The data collection process has not completed</li>
+                <li>The system is still processing your cloud inventory</li>
+                <li>There may be a connectivity issue with your AWS accounts</li>
+              </ul>
+
+              <h3 class="govuk-heading-m">What you can do</h3>
+
+              <ul class="govuk-list govuk-list--bullet">
+                <li>Check back in a few minutes once data collection completes</li>
+                <li>Verify that your AWS accounts are properly configured</li>
+                <li>Contact your administrator if this problem persists</li>
+              </ul>
+
+              <p class="govuk-body">
+                In the meantime, you can still access individual compliance reports and policy documents using the links below.
+              </p>
+            </div>
           </div>
+
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
         {% endif %}
 
         <div class="govuk-grid-row">


### PR DESCRIPTION
…ata pages

- Create reusable no-data.njk template with GOV.UK Design System styling
- Replace all "Internal Server Error" responses in compliance routes with contextual no-data pages
- Update overview/dashboard to show informative no-data message instead of basic warning
- Fix mock_aws_to_mongo.py script to generate account mappings in new schema format
- Update template condition to properly detect missing dashboard data

Routes updated:
- Database compliance (both main and details routes)
- KMS compliance (both main and details routes)
- Load balancers compliance (4 routes: tls, details, types, types/details)
- Auto scaling compliance (3 routes: dimensions, dimensions/details, empty)
- Tagging compliance (teams and details routes)
- Overview dashboard page

Each no-data page now includes:
- Contextual breadcrumbs and page titles
- Clear explanations of why data might be missing
- Helpful suggestions for next steps
- Navigation links back to overview/reports

🤖 Generated with [Claude Code](https://claude.ai/code)