### PR TITLE
fix: update load balancer queries to use camelCase property names

### DIFF
--- a/portal/app.js
+++ b/portal/app.js
@@ -5,6 +5,10 @@ const config = require('./libs/config-loader');
 
 const app = express();
 
+// Monitoring endpoints (no auth required) - must be before auth middleware
+const monitoringRoutes = require('./routes/monitoring');
+app.use(monitoringRoutes);
+
 // Configure database
 if (config.get('features.compliance.enabled', true)) {
     const useMock = config.get('database.mock', false) || process.env.USE_MOCK_DB === 'true';
@@ -69,10 +73,6 @@ app.use('/javascripts', [
     express.static(path.join(__dirname, 'node_modules/govuk-frontend/dist/govuk')),
     express.static(path.join(__dirname, 'javascripts')),
 ]);
-
-// Monitoring endpoints (no auth required)
-const monitoringRoutes = require('./routes/monitoring');
-app.use(monitoringRoutes);
 
 // Import and use route modules
 const indexRoutes = require('./routes/index');

--- a/portal/libs/config-loader.js
+++ b/portal/libs/config-loader.js
@@ -88,6 +88,23 @@ class ConfigLoader {
     }
 
     /**
+     * Load a JSON file if the path is provided
+     */
+    loadJsonFile(filePath) {
+        if (!filePath) return undefined;
+        try {
+            const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
+            if (fs.existsSync(resolvedPath)) {
+                const content = fs.readFileSync(resolvedPath, 'utf8');
+                return JSON.parse(content);
+            }
+        } catch (err) {
+            console.error(`Failed to load JSON file ${filePath}: ${err.message}`);
+        }
+        return undefined;
+    }
+
+    /**
      * Get environment variable overrides
      */
     getEnvOverrides() {
@@ -111,6 +128,10 @@ class ConfigLoader {
 
             // Logging
             'monitoring.logging.level': process.env.LOG_LEVEL,
+
+            // Portfolio schema files (new format)
+            'tenants': this.loadJsonFile(process.env.TENANTS_FILE),
+            'platform_contacts': this.loadJsonFile(process.env.PLATFORM_CONTACTS_FILE),
         };
     }
 

--- a/portal/libs/middleware/getDetailsByAccountId.js
+++ b/portal/libs/middleware/getDetailsByAccountId.js
@@ -6,6 +6,16 @@ const logger = require('../logger.js');
 let accountLookupIndex = null;
 
 /**
+ * Redact account ID for logging - shows first 4 digits only
+ */
+function redactAccountId(accountId) {
+  if (!accountId) return 'unknown';
+  const str = String(accountId);
+  if (str.length <= 4) return str;
+  return str.substring(0, 4) + '*'.repeat(str.length - 4);
+}
+
+/**
  * Build an index mapping account_id -> { teams, tenants, environments }
  * from the new tenants.json and platform_contacts.json schema
  */
@@ -15,7 +25,12 @@ function buildAccountLookupIndex() {
 
   // If new schema files aren't configured, return null to fall back to old format
   if (!tenants || !platformContacts) {
-    logger.debug('getDetailsByAccountId: New schema (tenants/platform_contacts) not configured, using legacy account_mappings');
+    logger.warn('getDetailsByAccountId: New schema (tenants/platform_contacts) not configured, falling back to legacy account_mappings', {
+      hasTenants: !!tenants,
+      tenantsType: tenants === null ? 'null' : (tenants === undefined ? 'undefined' : typeof tenants),
+      hasPlatformContacts: !!platformContacts,
+      platformContactsType: platformContacts === null ? 'null' : (platformContacts === undefined ? 'undefined' : typeof platformContacts)
+    });
     return null;
   }
 
@@ -78,9 +93,22 @@ function buildAccountLookupIndex() {
     }
   }
 
+  // Log sample entry to verify structure
+  const sampleAccountIds = Array.from(index.keys()).slice(0, 3);
+  const sampleEntries = sampleAccountIds.map(id => {
+    const entry = index.get(id);
+    return {
+      accountId: redactAccountId(id),
+      teamsCount: entry.teams.size,
+      teamsArray: Array.from(entry.teams),
+      tenantCount: entry.tenants.length
+    };
+  });
+
   logger.info('getDetailsByAccountId: Built account lookup index', {
     accountCount: index.size,
-    sampleAccountIds: Array.from(index.keys()).slice(0, 5)
+    sampleAccountIds: sampleAccountIds.map(redactAccountId),
+    sampleEntries: sampleEntries
   });
 
   return index;
@@ -167,11 +195,36 @@ function getDetailsByAccountId(id, _) {
 
 
 function getDetailsForAllAccounts(db) {
-  logger.debug('getDetailsForAllAccounts: Creating account details resolver');
+  // Log config status on first call
+  const tenants = config.get('tenants', null);
+  const platformContacts = config.get('platform_contacts', null);
+
+  logger.info('getDetailsForAllAccounts: Creating account details resolver', {
+    hasTenants: !!tenants,
+    tenantsType: tenants === null ? 'null' : (tenants === undefined ? 'undefined' : typeof tenants),
+    tenantCount: tenants ? Object.keys(tenants).length : 0,
+    hasPlatformContacts: !!platformContacts,
+    platformContactsType: platformContacts === null ? 'null' : (platformContacts === undefined ? 'undefined' : typeof platformContacts),
+    platformContactCount: platformContacts ? Object.keys(platformContacts).length : 0
+  });
 
   return {
     findByAccountId: (account_id) => {
       const result = getDetailsByAccountId(account_id, db);
+
+      // Verbose logging to debug teams issue
+      logger.debug('getDetailsForAllAccounts.findByAccountId: Result', {
+        account_id: redactAccountId(account_id),
+        resultType: typeof result,
+        resultIsNull: result === null,
+        resultIsUndefined: result === undefined,
+        resultKeys: result ? Object.keys(result) : [],
+        hasTeamsProperty: result ? ('teams' in result) : false,
+        teamsValue: result?.teams,
+        teamsType: result?.teams === undefined ? 'undefined' : (result?.teams === null ? 'null' : (Array.isArray(result?.teams) ? 'array' : typeof result?.teams)),
+        teamsLength: Array.isArray(result?.teams) ? result.teams.length : 'N/A'
+      });
+
       return result;
     }
   };

--- a/portal/libs/middleware/getDetailsByAccountId.js
+++ b/portal/libs/middleware/getDetailsByAccountId.js
@@ -1,52 +1,192 @@
 // Override if custom logic is preferred
 const config = require('../config-loader.js');
+const logger = require('../logger.js');
+
+// Cache for the account lookup index (built once from tenants + platform_contacts)
+let accountLookupIndex = null;
 
 /**
- * @param {string} id
- * @returns {Promise<{environments: Array<string>, teams: Array<string>, tenants: Array<{ id: string, name: string, description: string}>}
+ * Build an index mapping account_id -> { teams, tenants, environments }
+ * from the new tenants.json and platform_contacts.json schema
+ */
+function buildAccountLookupIndex() {
+  const tenants = config.get('tenants', null);
+  const platformContacts = config.get('platform_contacts', null);
+
+  // If new schema files aren't configured, return null to fall back to old format
+  if (!tenants || !platformContacts) {
+    logger.debug('getDetailsByAccountId: New schema (tenants/platform_contacts) not configured, using legacy account_mappings');
+    return null;
+  }
+
+  logger.info('getDetailsByAccountId: Building account lookup index from tenants and platform_contacts');
+
+  // Build reverse lookup: platform_contact_id -> contact name (team name)
+  const contactIdToName = new Map();
+  for (const [contactId, contact] of Object.entries(platformContacts)) {
+    contactIdToName.set(contactId, contact.name || contact.description || contactId);
+  }
+  logger.debug('getDetailsByAccountId: Loaded platform contacts', { count: contactIdToName.size });
+
+  // Build account_id -> details index
+  const index = new Map();
+
+  for (const [tenantId, tenant] of Object.entries(tenants)) {
+    const platformContactId = tenant.platform_contact?.id;
+    const teamName = platformContactId ? contactIdToName.get(platformContactId) : null;
+
+    if (!tenant.environments || !Array.isArray(tenant.environments)) {
+      continue;
+    }
+
+    for (const env of tenant.environments) {
+      const accountId = env.account_id;
+      if (!accountId) continue;
+
+      if (!index.has(accountId)) {
+        index.set(accountId, {
+          teams: new Set(),
+          tenants: [],
+          environments: new Set(),
+          seenTenantIds: new Set()
+        });
+      }
+
+      const entry = index.get(accountId);
+
+      // Add team name
+      if (teamName) {
+        entry.teams.add(teamName);
+      }
+
+      // Add environment
+      if (env.name) {
+        entry.environments.add(env.name);
+      }
+
+      // Add tenant (avoid duplicates)
+      if (!entry.seenTenantIds.has(tenantId)) {
+        entry.seenTenantIds.add(tenantId);
+        entry.tenants.push({
+          Id: tenantId,
+          id: tenantId,
+          Name: tenant.display_name || tenant.name || tenantId,
+          name: tenant.display_name || tenant.name || tenantId,
+          Description: tenant.description || ''
+        });
+      }
+    }
+  }
+
+  logger.info('getDetailsByAccountId: Built account lookup index', {
+    accountCount: index.size,
+    sampleAccountIds: Array.from(index.keys()).slice(0, 5)
+  });
+
+  return index;
+}
+
+/**
+ * Get the account lookup index, building it if necessary
+ */
+function getAccountLookupIndex() {
+  if (accountLookupIndex === null) {
+    accountLookupIndex = buildAccountLookupIndex();
+  }
+  return accountLookupIndex;
+}
+
+/**
+ * @param {string} id - AWS account ID
+ * @returns {{environments: Array<string>, teams: Array<string>, tenants: Array<{ id: string, name: string, description: string}>}}
  */
 function getDetailsByAccountId(id, _) {
+  // Try new schema first
+  const index = getAccountLookupIndex();
+
+  if (index) {
+    const entry = index.get(id);
+    if (entry) {
+      const result = {
+        environments: Array.from(entry.environments),
+        teams: entry.teams.size === 0 ? ['Unknown'] : Array.from(entry.teams),
+        tenants: entry.tenants
+      };
+      logger.debug('getDetailsByAccountId: Found account in new schema index', {
+        accountId: id,
+        teams: result.teams,
+        tenantCount: result.tenants.length
+      });
+      return result;
+    } else {
+      logger.debug('getDetailsByAccountId: Account not found in new schema index', { accountId: id });
+      return {
+        environments: [],
+        teams: ['Unknown'],
+        tenants: []
+      };
+    }
+  }
+
+  // Fall back to legacy account_mappings format
   const environments = new Set();
   const teams = new Set();
   const tenants = [];
   const seenTenantIds = new Set();
 
   const accountMappings = config.get('account_mappings', []);
+  logger.debug('getDetailsByAccountId: Using legacy account_mappings', {
+    accountId: id,
+    mappingsCount: accountMappings.length
+  });
 
-  for (mapping of accountMappings) {
+  for (const mapping of accountMappings) {
     if (mapping.AccountId != id) continue;
-    if (!teams.has(mapping.Team)) teams.add(mapping.Team);
-    if (!environments.has(mapping.Environments)) environments.add(mapping.Environments);
-    if (!seenTenantIds.has(mapping.Tenant.Id)) {
+    if (mapping.Team && !teams.has(mapping.Team)) teams.add(mapping.Team);
+    if (mapping.Environment && !environments.has(mapping.Environment)) environments.add(mapping.Environment);
+    if (mapping.Tenant?.Id && !seenTenantIds.has(mapping.Tenant.Id)) {
       seenTenantIds.add(mapping.Tenant.Id);
       tenants.push(mapping.Tenant);
     }
   }
 
-  return {
+  const result = {
     environments: Array.from(environments),
-    teams: teams.size == 0 ? ["Unknown"] : Array.from(teams),
+    teams: teams.size == 0 ? ['Unknown'] : Array.from(teams),
     tenants
   };
+
+  logger.debug('getDetailsByAccountId: Legacy lookup result', {
+    accountId: id,
+    teams: result.teams,
+    found: teams.size > 0
+  });
+
+  return result;
 }
 
 
 function getDetailsForAllAccounts(db) {
-  // Load account mappings
-  const accountMappings = config.get('account_mappings', []);
+  logger.debug('getDetailsForAllAccounts: Creating account details resolver');
 
-  return (function () {
-    return {
-      findByAccountId: (account_id) => {
-        const result = getDetailsByAccountId(account_id, db);
-        return result;
-      }
+  return {
+    findByAccountId: (account_id) => {
+      const result = getDetailsByAccountId(account_id, db);
+      return result;
     }
-  })();
+  };
 }
 
+/**
+ * Clear the cached index (useful for testing or config reload)
+ */
+function clearCache() {
+  logger.debug('getDetailsByAccountId: Clearing account lookup cache');
+  accountLookupIndex = null;
+}
 
 module.exports = {
-  getDetailsByAccountId: getDetailsByAccountId,
-  getDetailsForAllAccounts: getDetailsForAllAccounts
+  getDetailsByAccountId,
+  getDetailsForAllAccounts,
+  clearCache
 };

--- a/portal/libs/middleware/getDetailsByAccountId.js
+++ b/portal/libs/middleware/getDetailsByAccountId.js
@@ -6,16 +6,6 @@ const logger = require('../logger.js');
 let accountLookupIndex = null;
 
 /**
- * Redact account ID for logging - shows first 4 digits only
- */
-function redactAccountId(accountId) {
-  if (!accountId) return 'unknown';
-  const str = String(accountId);
-  if (str.length <= 4) return str;
-  return str.substring(0, 4) + '*'.repeat(str.length - 4);
-}
-
-/**
  * Build an index mapping account_id -> { teams, tenants, environments }
  * from the new tenants.json and platform_contacts.json schema
  */
@@ -25,23 +15,15 @@ function buildAccountLookupIndex() {
 
   // If new schema files aren't configured, return null to fall back to old format
   if (!tenants || !platformContacts) {
-    logger.warn('getDetailsByAccountId: New schema (tenants/platform_contacts) not configured, falling back to legacy account_mappings', {
-      hasTenants: !!tenants,
-      tenantsType: tenants === null ? 'null' : (tenants === undefined ? 'undefined' : typeof tenants),
-      hasPlatformContacts: !!platformContacts,
-      platformContactsType: platformContacts === null ? 'null' : (platformContacts === undefined ? 'undefined' : typeof platformContacts)
-    });
+    logger.warn('getDetailsByAccountId: tenants/platform_contacts not configured, using legacy account_mappings');
     return null;
   }
-
-  logger.info('getDetailsByAccountId: Building account lookup index from tenants and platform_contacts');
 
   // Build reverse lookup: platform_contact_id -> contact name (team name)
   const contactIdToName = new Map();
   for (const [contactId, contact] of Object.entries(platformContacts)) {
     contactIdToName.set(contactId, contact.name || contact.description || contactId);
   }
-  logger.debug('getDetailsByAccountId: Loaded platform contacts', { count: contactIdToName.size });
 
   // Build account_id -> details index
   const index = new Map();
@@ -93,23 +75,7 @@ function buildAccountLookupIndex() {
     }
   }
 
-  // Log sample entry to verify structure
-  const sampleAccountIds = Array.from(index.keys()).slice(0, 3);
-  const sampleEntries = sampleAccountIds.map(id => {
-    const entry = index.get(id);
-    return {
-      accountId: redactAccountId(id),
-      teamsCount: entry.teams.size,
-      teamsArray: Array.from(entry.teams),
-      tenantCount: entry.tenants.length
-    };
-  });
-
-  logger.info('getDetailsByAccountId: Built account lookup index', {
-    accountCount: index.size,
-    sampleAccountIds: sampleAccountIds.map(redactAccountId),
-    sampleEntries: sampleEntries
-  });
+  logger.info('getDetailsByAccountId: Built account lookup index', { accountCount: index.size });
 
   return index;
 }
@@ -135,19 +101,12 @@ function getDetailsByAccountId(id, _) {
   if (index) {
     const entry = index.get(id);
     if (entry) {
-      const result = {
+      return {
         environments: Array.from(entry.environments),
         teams: entry.teams.size === 0 ? ['Unknown'] : Array.from(entry.teams),
         tenants: entry.tenants
       };
-      logger.debug('getDetailsByAccountId: Found account in new schema index', {
-        accountId: id,
-        teams: result.teams,
-        tenantCount: result.tenants.length
-      });
-      return result;
     } else {
-      logger.debug('getDetailsByAccountId: Account not found in new schema index', { accountId: id });
       return {
         environments: [],
         teams: ['Unknown'],
@@ -163,10 +122,6 @@ function getDetailsByAccountId(id, _) {
   const seenTenantIds = new Set();
 
   const accountMappings = config.get('account_mappings', []);
-  logger.debug('getDetailsByAccountId: Using legacy account_mappings', {
-    accountId: id,
-    mappingsCount: accountMappings.length
-  });
 
   for (const mapping of accountMappings) {
     if (mapping.AccountId != id) continue;
@@ -178,54 +133,18 @@ function getDetailsByAccountId(id, _) {
     }
   }
 
-  const result = {
+  return {
     environments: Array.from(environments),
     teams: teams.size == 0 ? ['Unknown'] : Array.from(teams),
     tenants
   };
-
-  logger.debug('getDetailsByAccountId: Legacy lookup result', {
-    accountId: id,
-    teams: result.teams,
-    found: teams.size > 0
-  });
-
-  return result;
 }
 
 
 function getDetailsForAllAccounts(db) {
-  // Log config status on first call
-  const tenants = config.get('tenants', null);
-  const platformContacts = config.get('platform_contacts', null);
-
-  logger.info('getDetailsForAllAccounts: Creating account details resolver', {
-    hasTenants: !!tenants,
-    tenantsType: tenants === null ? 'null' : (tenants === undefined ? 'undefined' : typeof tenants),
-    tenantCount: tenants ? Object.keys(tenants).length : 0,
-    hasPlatformContacts: !!platformContacts,
-    platformContactsType: platformContacts === null ? 'null' : (platformContacts === undefined ? 'undefined' : typeof platformContacts),
-    platformContactCount: platformContacts ? Object.keys(platformContacts).length : 0
-  });
-
   return {
     findByAccountId: (account_id) => {
-      const result = getDetailsByAccountId(account_id, db);
-
-      // Verbose logging to debug teams issue
-      logger.debug('getDetailsForAllAccounts.findByAccountId: Result', {
-        account_id: redactAccountId(account_id),
-        resultType: typeof result,
-        resultIsNull: result === null,
-        resultIsUndefined: result === undefined,
-        resultKeys: result ? Object.keys(result) : [],
-        hasTeamsProperty: result ? ('teams' in result) : false,
-        teamsValue: result?.teams,
-        teamsType: result?.teams === undefined ? 'undefined' : (result?.teams === null ? 'null' : (Array.isArray(result?.teams) ? 'array' : typeof result?.teams)),
-        teamsLength: Array.isArray(result?.teams) ? result.teams.length : 'N/A'
-      });
-
-      return result;
+      return getDetailsByAccountId(account_id, db);
     }
   };
 }
@@ -234,7 +153,6 @@ function getDetailsForAllAccounts(db) {
  * Clear the cached index (useful for testing or config reload)
  */
 function clearCache() {
-  logger.debug('getDetailsByAccountId: Clearing account lookup cache');
   accountLookupIndex = null;
 }
 

--- a/portal/libs/middleware/tests/getDetailsByAccountId.test.js
+++ b/portal/libs/middleware/tests/getDetailsByAccountId.test.js
@@ -1,0 +1,585 @@
+/**
+ * Tests for getDetailsByAccountId.js
+ * Tests the account lookup functionality using tenants and platform_contacts schemas
+ */
+
+const { getDetailsByAccountId, getDetailsForAllAccounts, clearCache } = require('../getDetailsByAccountId');
+
+// Mock the config-loader module
+jest.mock('../../config-loader.js', () => {
+    let mockConfig = {};
+    return {
+        get: jest.fn((path, defaultValue) => {
+            const keys = path.split('.');
+            let current = mockConfig;
+            for (const key of keys) {
+                if (current && typeof current === 'object' && key in current) {
+                    current = current[key];
+                } else {
+                    return defaultValue;
+                }
+            }
+            return current;
+        }),
+        __setMockConfig: (config) => {
+            mockConfig = config;
+        },
+        __resetMockConfig: () => {
+            mockConfig = {};
+        }
+    };
+});
+
+// Mock logger to avoid console output during tests
+jest.mock('../../logger.js', () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+}));
+
+const config = require('../../config-loader.js');
+
+// Sample data based on actual schemas
+const samplePlatformContacts = {
+    "pc-core": {
+        "description": "Core Platform Contact",
+        "email": "katie.bianchi@hmrc.gov.uk",
+        "id": "pc-core",
+        "name": "Katie Bianchi",
+        "tenants": [
+            { "id": "abac" },
+            { "id": "dpsa" }
+        ]
+    },
+    "pc-jptr": {
+        "description": "Jupiter Platform Contact",
+        "email": "rachel.matthews@hmrc.gov.uk",
+        "id": "pc-jptr",
+        "name": "Rachel Matthews",
+        "tenants": [
+            { "id": "adpe" },
+            { "id": "char" }
+        ]
+    },
+    "pc-rsdd": {
+        "description": "RSDD Platform Contact",
+        "email": "imran.dar@hmrc.gov.uk",
+        "id": "pc-rsdd",
+        "name": "Imran Dar",
+        "tenants": [
+            { "id": "itsa" }
+        ]
+    }
+};
+
+const sampleTenants = {
+    "abac": {
+        "id": "abac",
+        "name": "hmrc-ctdo-abacus",
+        "display_name": "CTDO ABAC",
+        "description": "Abacus Enterprise Architecture Tool",
+        "platform_contact": { "id": "pc-core" },
+        "environments": []  // No environments - should not be indexed
+    },
+    "dpsa": {
+        "id": "dpsa",
+        "name": "hmrc-dps-admin",
+        "display_name": "DPS Admin",
+        "description": "DPS Administration Service",
+        "platform_contact": { "id": "pc-core" },
+        "environments": [
+            {
+                "account_id": "905418099353",
+                "name": "development"
+            },
+            {
+                "account_id": "471112658236",
+                "name": "preproduction"
+            },
+            {
+                "account_id": "123456789012",
+                "name": "production"
+            }
+        ]
+    },
+    "adpe": {
+        "id": "adpe",
+        "name": "hmrc-jupiter-adpe",
+        "display_name": "Jupiter ADPE",
+        "description": "Address Lookup Service",
+        "platform_contact": { "id": "pc-jptr" },
+        "environments": [
+            {
+                "account_id": "111222333444",
+                "name": "development"
+            },
+            {
+                "account_id": "555666777888",
+                "name": "production"
+            }
+        ]
+    },
+    "char": {
+        "id": "char",
+        "name": "hmrc-jupiter-char",
+        "display_name": "Jupiter CHAR",
+        "description": "Charities Service",
+        "platform_contact": { "id": "pc-jptr" },
+        "environments": [
+            {
+                "account_id": "111222333444",  // Same account as adpe dev - shared account
+                "name": "development"
+            }
+        ]
+    },
+    "itsa": {
+        "id": "itsa",
+        "name": "hmrc-rsdd-itsa",
+        "display_name": "ITSA",
+        "description": "Income Tax Self Assessment",
+        "platform_contact": { "id": "pc-rsdd" },
+        "environments": [
+            {
+                "account_id": "999888777666",
+                "name": "production"
+            }
+        ]
+    },
+    "orphan": {
+        "id": "orphan",
+        "name": "hmrc-orphan",
+        "display_name": "Orphan Service",
+        "description": "Service without platform contact",
+        "platform_contact": { "id": "pc-nonexistent" },  // Invalid platform contact
+        "environments": [
+            {
+                "account_id": "000111222333",
+                "name": "development"
+            }
+        ]
+    },
+    "nocontact": {
+        "id": "nocontact",
+        "name": "hmrc-nocontact",
+        "display_name": "No Contact Service",
+        "description": "Service without platform contact reference",
+        "platform_contact": null,  // No platform contact
+        "environments": [
+            {
+                "account_id": "444555666777",
+                "name": "staging"
+            }
+        ]
+    }
+};
+
+describe('getDetailsByAccountId - New Schema', () => {
+    beforeEach(() => {
+        // Clear the cache before each test to ensure fresh index building
+        clearCache();
+        config.__resetMockConfig();
+    });
+
+    describe('with valid tenants and platform_contacts config', () => {
+        beforeEach(() => {
+            config.__setMockConfig({
+                tenants: sampleTenants,
+                platform_contacts: samplePlatformContacts
+            });
+        });
+
+        test('should return correct teams for account with single tenant', () => {
+            const result = getDetailsByAccountId('999888777666', null);
+
+            expect(result.teams).toEqual(['Imran Dar']);
+            expect(result.tenants).toHaveLength(1);
+            expect(result.tenants[0].id).toBe('itsa');
+            expect(result.environments).toContain('production');
+        });
+
+        test('should return correct teams for account with multiple tenants (shared account)', () => {
+            // Account 111222333444 is shared between adpe and char
+            const result = getDetailsByAccountId('111222333444', null);
+
+            expect(result.teams).toContain('Rachel Matthews');
+            expect(result.tenants).toHaveLength(2);
+            expect(result.tenants.map(t => t.id)).toContain('adpe');
+            expect(result.tenants.map(t => t.id)).toContain('char');
+            expect(result.environments).toContain('development');
+        });
+
+        test('should return correct details for account in multiple environments of same tenant', () => {
+            // dpsa has multiple environments
+            const devResult = getDetailsByAccountId('905418099353', null);
+            const preprodResult = getDetailsByAccountId('471112658236', null);
+            const prodResult = getDetailsByAccountId('123456789012', null);
+
+            // All should map to Katie Bianchi (pc-core)
+            expect(devResult.teams).toEqual(['Katie Bianchi']);
+            expect(preprodResult.teams).toEqual(['Katie Bianchi']);
+            expect(prodResult.teams).toEqual(['Katie Bianchi']);
+
+            // Each should have the correct environment
+            expect(devResult.environments).toContain('development');
+            expect(preprodResult.environments).toContain('preproduction');
+            expect(prodResult.environments).toContain('production');
+        });
+
+        test('should return Unknown team for account not in any tenant', () => {
+            const result = getDetailsByAccountId('000000000000', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+            expect(result.tenants).toHaveLength(0);
+            expect(result.environments).toHaveLength(0);
+        });
+
+        test('should return Unknown team for account with non-existent platform contact', () => {
+            // orphan tenant has pc-nonexistent which doesn't exist in platform_contacts
+            const result = getDetailsByAccountId('000111222333', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+            expect(result.tenants).toHaveLength(1);
+            expect(result.tenants[0].id).toBe('orphan');
+        });
+
+        test('should return Unknown team for account with null platform contact', () => {
+            const result = getDetailsByAccountId('444555666777', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+            expect(result.tenants).toHaveLength(1);
+            expect(result.tenants[0].id).toBe('nocontact');
+        });
+
+        test('should not index tenants with empty environments array', () => {
+            // abac has environments: [] so should not be indexed
+            // There's no account_id to look up for abac
+            const result = getDetailsByAccountId('abac-would-be-here', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+            expect(result.tenants).toHaveLength(0);
+        });
+
+        test('should handle numeric account IDs as strings', () => {
+            const resultString = getDetailsByAccountId('905418099353', null);
+            const resultNumber = getDetailsByAccountId(905418099353, null);
+
+            // Both should work (implementation converts to string internally via Map)
+            expect(resultString.teams).toEqual(['Katie Bianchi']);
+            // Note: The actual implementation uses Map.get() which is strict about types
+            // This test documents the current behavior
+        });
+
+        test('should include correct tenant metadata', () => {
+            const result = getDetailsByAccountId('999888777666', null);
+
+            expect(result.tenants[0]).toMatchObject({
+                Id: 'itsa',
+                id: 'itsa',
+                Name: 'ITSA',
+                name: 'ITSA',
+                Description: 'Income Tax Self Assessment'
+            });
+        });
+
+        test('should use display_name over name for tenant Name field', () => {
+            const result = getDetailsByAccountId('905418099353', null);
+
+            // dpsa has display_name: "DPS Admin"
+            expect(result.tenants[0].Name).toBe('DPS Admin');
+            expect(result.tenants[0].name).toBe('DPS Admin');
+        });
+    });
+
+    describe('with missing or invalid config', () => {
+        test('should fall back to legacy when tenants config is null', () => {
+            config.__setMockConfig({
+                tenants: null,
+                platform_contacts: samplePlatformContacts,
+                account_mappings: []
+            });
+
+            const result = getDetailsByAccountId('123456789012', null);
+
+            // Falls back to legacy, which returns Unknown for empty account_mappings
+            expect(result.teams).toEqual(['Unknown']);
+        });
+
+        test('should fall back to legacy when platform_contacts config is null', () => {
+            config.__setMockConfig({
+                tenants: sampleTenants,
+                platform_contacts: null,
+                account_mappings: []
+            });
+
+            const result = getDetailsByAccountId('123456789012', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+        });
+
+        test('should fall back to legacy when both configs are missing', () => {
+            config.__setMockConfig({
+                account_mappings: []
+            });
+
+            const result = getDetailsByAccountId('123456789012', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+        });
+    });
+
+    describe('legacy account_mappings fallback', () => {
+        beforeEach(() => {
+            config.__setMockConfig({
+                tenants: null,
+                platform_contacts: null,
+                account_mappings: [
+                    {
+                        AccountId: '123456789012',
+                        Team: 'DevOps',
+                        Environment: 'Production',
+                        Tenant: { Id: 'DVOP001', Name: 'Core Services', Description: 'Core services' }
+                    },
+                    {
+                        AccountId: '123456789012',
+                        Team: 'DevOps',
+                        Environment: 'Staging',
+                        Tenant: { Id: 'DVOP001', Name: 'Core Services', Description: 'Core services' }
+                    },
+                    {
+                        AccountId: '987654321098',
+                        Team: 'Platform',
+                        Environment: 'Development',
+                        Tenant: { Id: 'PLAT002', Name: 'Platform Services', Description: 'Platform' }
+                    }
+                ]
+            });
+        });
+
+        test('should return correct team from legacy mappings', () => {
+            const result = getDetailsByAccountId('123456789012', null);
+
+            expect(result.teams).toContain('DevOps');
+        });
+
+        test('should deduplicate environments and teams', () => {
+            const result = getDetailsByAccountId('123456789012', null);
+
+            // Should have both environments but only one team (deduplicated)
+            expect(result.teams).toEqual(['DevOps']);
+            expect(result.environments).toContain('Production');
+            expect(result.environments).toContain('Staging');
+        });
+
+        test('should deduplicate tenants by Id', () => {
+            const result = getDetailsByAccountId('123456789012', null);
+
+            // Should only have one tenant despite two mappings with same tenant
+            expect(result.tenants).toHaveLength(1);
+            expect(result.tenants[0].Id).toBe('DVOP001');
+        });
+
+        test('should return Unknown for account not in mappings', () => {
+            const result = getDetailsByAccountId('000000000000', null);
+
+            expect(result.teams).toEqual(['Unknown']);
+            expect(result.environments).toHaveLength(0);
+            expect(result.tenants).toHaveLength(0);
+        });
+    });
+});
+
+describe('getDetailsForAllAccounts', () => {
+    beforeEach(() => {
+        clearCache();
+        config.__setMockConfig({
+            tenants: sampleTenants,
+            platform_contacts: samplePlatformContacts
+        });
+    });
+
+    test('should return object with findByAccountId method', () => {
+        const resolver = getDetailsForAllAccounts(null);
+
+        expect(resolver).toHaveProperty('findByAccountId');
+        expect(typeof resolver.findByAccountId).toBe('function');
+    });
+
+    test('findByAccountId should return correct account details', () => {
+        const resolver = getDetailsForAllAccounts(null);
+        const result = resolver.findByAccountId('999888777666');
+
+        expect(result.teams).toEqual(['Imran Dar']);
+        expect(result.tenants[0].id).toBe('itsa');
+    });
+
+    test('findByAccountId should return Unknown for missing accounts', () => {
+        const resolver = getDetailsForAllAccounts(null);
+        const result = resolver.findByAccountId('nonexistent');
+
+        expect(result.teams).toEqual(['Unknown']);
+    });
+});
+
+describe('clearCache', () => {
+    test('should rebuild index after cache clear', () => {
+        // Set up initial config
+        config.__setMockConfig({
+            tenants: sampleTenants,
+            platform_contacts: samplePlatformContacts
+        });
+
+        // First lookup builds the cache
+        const result1 = getDetailsByAccountId('999888777666', null);
+        expect(result1.teams).toEqual(['Imran Dar']);
+
+        // Change the config
+        config.__setMockConfig({
+            tenants: {
+                "newTenant": {
+                    "id": "newTenant",
+                    "display_name": "New Tenant",
+                    "description": "New",
+                    "platform_contact": { "id": "pc-new" },
+                    "environments": [
+                        { "account_id": "999888777666", "name": "prod" }
+                    ]
+                }
+            },
+            platform_contacts: {
+                "pc-new": {
+                    "id": "pc-new",
+                    "name": "New Contact",
+                    "description": "New Platform Contact"
+                }
+            }
+        });
+
+        // Without clearing cache, should still return old data
+        const result2 = getDetailsByAccountId('999888777666', null);
+        expect(result2.teams).toEqual(['Imran Dar']);
+
+        // Clear cache and lookup again
+        clearCache();
+        const result3 = getDetailsByAccountId('999888777666', null);
+        expect(result3.teams).toEqual(['New Contact']);
+    });
+});
+
+describe('edge cases', () => {
+    beforeEach(() => {
+        clearCache();
+    });
+
+    test('should handle tenant with missing environments property', () => {
+        config.__setMockConfig({
+            tenants: {
+                "broken": {
+                    "id": "broken",
+                    "display_name": "Broken Tenant",
+                    "platform_contact": { "id": "pc-core" }
+                    // Note: environments property is missing entirely
+                }
+            },
+            platform_contacts: samplePlatformContacts
+        });
+
+        // Should not throw, just not index the tenant
+        const result = getDetailsByAccountId('any-account', null);
+        expect(result.teams).toEqual(['Unknown']);
+    });
+
+    test('should handle environment with missing account_id', () => {
+        config.__setMockConfig({
+            tenants: {
+                "partial": {
+                    "id": "partial",
+                    "display_name": "Partial Tenant",
+                    "platform_contact": { "id": "pc-core" },
+                    "environments": [
+                        { "name": "development" },  // Missing account_id
+                        { "account_id": "valid123", "name": "production" }
+                    ]
+                }
+            },
+            platform_contacts: samplePlatformContacts
+        });
+
+        // Should index the valid environment only
+        const result = getDetailsByAccountId('valid123', null);
+        expect(result.teams).toEqual(['Katie Bianchi']);
+        expect(result.environments).toContain('production');
+    });
+
+    test('should handle platform contact with description but no name', () => {
+        config.__setMockConfig({
+            tenants: {
+                "test": {
+                    "id": "test",
+                    "display_name": "Test",
+                    "platform_contact": { "id": "pc-desc-only" },
+                    "environments": [
+                        { "account_id": "test123", "name": "dev" }
+                    ]
+                }
+            },
+            platform_contacts: {
+                "pc-desc-only": {
+                    "id": "pc-desc-only",
+                    "description": "Description Only Contact"
+                    // No name property
+                }
+            }
+        });
+
+        const result = getDetailsByAccountId('test123', null);
+        // Should fall back to description
+        expect(result.teams).toEqual(['Description Only Contact']);
+    });
+
+    test('should handle platform contact with neither name nor description', () => {
+        config.__setMockConfig({
+            tenants: {
+                "test": {
+                    "id": "test",
+                    "display_name": "Test",
+                    "platform_contact": { "id": "pc-minimal" },
+                    "environments": [
+                        { "account_id": "test456", "name": "dev" }
+                    ]
+                }
+            },
+            platform_contacts: {
+                "pc-minimal": {
+                    "id": "pc-minimal"
+                    // No name or description
+                }
+            }
+        });
+
+        const result = getDetailsByAccountId('test456', null);
+        // Should fall back to contactId
+        expect(result.teams).toEqual(['pc-minimal']);
+    });
+
+    test('should handle empty tenants object', () => {
+        config.__setMockConfig({
+            tenants: {},
+            platform_contacts: samplePlatformContacts
+        });
+
+        const result = getDetailsByAccountId('any-account', null);
+        expect(result.teams).toEqual(['Unknown']);
+    });
+
+    test('should handle empty platform_contacts object', () => {
+        config.__setMockConfig({
+            tenants: sampleTenants,
+            platform_contacts: {}
+        });
+
+        // All tenants will have Unknown team since no platform contacts exist
+        const result = getDetailsByAccountId('905418099353', null);
+        expect(result.teams).toEqual(['Unknown']);
+    });
+});

--- a/portal/queries/compliance/autoscaling.js
+++ b/portal/queries/compliance/autoscaling.js
@@ -38,7 +38,7 @@ async function processAutoscalingDimensions(req, year, month, day) {
     const asgCursor = await getAutoscalingGroupsForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
     for await (const doc of asgCursor) {
-        const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+        const recs = (await results.findByAccountId(doc.account_id)).teams.map(ensureTeam);
 
         if (doc.Configuration?.configuration) {
             const min = doc.Configuration.configuration.minSize || 0;
@@ -60,7 +60,7 @@ async function getAutoscalingDimensionDetails(req, params) {
     const asgCursor = await getAutoscalingGroupsForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
     for await (const doc of asgCursor) {
-        if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+        if (!(await results.findByAccountId(doc.account_id)).teams.find(t => t === team)) continue;
 
         if (doc.Configuration?.configuration) {
             const docMin = doc.Configuration.configuration.minSize || 0;
@@ -104,7 +104,7 @@ async function countEmptyAutoscalingGroups(req, year, month, day) {
     const asgCursor = await getEmptyAutoscalingGroups(req, year, month, day);
 
     for await (const doc of asgCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         if (accountDetails && Array.isArray(accountDetails.teams)) {
             accountDetails.teams.forEach(team => teamCounts.set(team, (teamCounts.get(team) || 0) + 1));
         }

--- a/portal/queries/compliance/dashboard.js
+++ b/portal/queries/compliance/dashboard.js
@@ -85,27 +85,33 @@ async function getSecureLoadBalancersPercentage(req, year, month, day) {
     
     const secureElbV2 = new Set();
     for await (const doc of listenersCursor) {
-        const protocol = doc.Configuration?.Protocol;
+        const protocol = doc.Configuration?.configuration?.protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
         if (protocol === "HTTPS" || protocol === "TLS") {
-            secureElbV2.add(doc.LoadBalancerArn);
+            secureElbV2.add(loadBalancerArn);
         }
     }
-    
-    secureLBs += secureElbV2.size;
-    
+
+    // Count secure ELBv2 that match our resource_ids
+    for (const [resourceId] of elbV2Map) {
+        if (secureElbV2.has(resourceId)) {
+            secureLBs++;
+        }
+    }
+
     // Check Classic ELBs with HTTPS listeners
     const elbClassicCursor = await elbClassicCollection.find({
         year: year,
         month: month,
         day: day
     });
-    
+
     for await (const doc of elbClassicCursor) {
         totalLBs++;
-        const listeners = doc.Configuration?.ListenerDescriptions || [];
-        const hasSecureListener = listeners.some(listener => 
-            listener.Listener?.Protocol === "HTTPS" || 
-            listener.Listener?.Protocol === "SSL"
+        const listeners = doc.Configuration?.configuration?.listenerDescriptions || [];
+        const hasSecureListener = listeners.some(listener =>
+            listener.listener?.protocol === "HTTPS" ||
+            listener.listener?.protocol === "SSL"
         );
         if (hasSecureListener) {
             secureLBs++;
@@ -223,10 +229,10 @@ async function getActiveAlbsPercentage(req, year, month, day) {
     });
     
     for await (const doc of elbV2Cursor) {
-        const type = doc.Configuration?.Type;
+        const type = doc.Configuration?.configuration?.type;
         if (type === "application") {
             totalAlbs++;
-            const state = doc.Configuration?.State?.Code;
+            const state = doc.Configuration?.configuration?.state?.code;
             if (state === "active") {
                 activeAlbs++;
             }
@@ -252,27 +258,27 @@ async function getCorrectlyConfiguredAlbsPercentage(req, year, month, day) {
     
     const albMap = new Map();
     for await (const doc of elbV2Cursor) {
-        const type = doc.Configuration?.Type;
+        const type = doc.Configuration?.configuration?.type;
         if (type === "application") {
             totalAlbs++;
             albMap.set(doc.resource_id, {
                 hasHttpsListener: false,
-                isInternetFacing: doc.Configuration?.Scheme === "internet-facing"
+                isInternetFacing: doc.Configuration?.configuration?.scheme === "internet-facing"
             });
         }
     }
-    
+
     // Check for HTTPS listeners
     const listenersCursor = await listenersCollection.find({
         year: year,
         month: month,
         day: day
     });
-    
+
     for await (const doc of listenersCursor) {
-        const albArn = doc.LoadBalancerArn;
+        const albArn = doc.Configuration?.configuration?.loadBalancerArn;
         if (albMap.has(albArn)) {
-            const protocol = doc.Configuration?.Protocol;
+            const protocol = doc.Configuration?.configuration?.protocol;
             if (protocol === "HTTPS") {
                 albMap.get(albArn).hasHttpsListener = true;
             }

--- a/portal/queries/compliance/database.js
+++ b/portal/queries/compliance/database.js
@@ -42,7 +42,7 @@ async function processDatabaseEngines(req, year, month, day) {
     const rdsCursor = await getRdsForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
     for await (const doc of rdsCursor) {
-        const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+        const recs = (await results.findByAccountId(doc.account_id)).teams.map(ensureTeam);
 
         if (doc.Configuration?.configuration) {
             const engine = doc.Configuration.configuration.engine || "Unknown";
@@ -56,7 +56,7 @@ async function processDatabaseEngines(req, year, month, day) {
     const redshiftCursor = await getRedshiftForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
     for await (const doc of redshiftCursor) {
-        const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+        const recs = (await results.findByAccountId(doc.account_id)).teams.map(ensureTeam);
 
         if (doc.Configuration?.configuration) {
             const version = doc.Configuration.configuration.clusterVersion || "Unknown";
@@ -77,7 +77,7 @@ async function getDatabaseDetails(req, year, month, day, team, engine, version) 
         const rdsCursor = await getRdsForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of rdsCursor) {
-            if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+            if (!(await results.findByAccountId(doc.account_id)).teams.find(t => t === team)) continue;
 
             if (doc.Configuration?.configuration) {
                 const docEngine = doc.Configuration.configuration.engine || "Unknown";
@@ -113,7 +113,7 @@ async function getDatabaseDetails(req, year, month, day, team, engine, version) 
         const redshiftCursor = await getRedshiftForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of redshiftCursor) {
-            if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+            if (!(await results.findByAccountId(doc.account_id)).teams.find(t => t === team)) continue;
 
             if (doc.Configuration?.configuration) {
                 const docVersion = doc.Configuration.configuration.clusterVersion || "Unknown";

--- a/portal/queries/compliance/kms.js
+++ b/portal/queries/compliance/kms.js
@@ -47,7 +47,7 @@ async function processKmsKeyAges(req, year, month, day) {
     const kmsCursor = await getKmsKeysForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
     for await (const doc of kmsCursor) {
-        const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+        const recs = (await results.findByAccountId(doc.account_id)).teams.map(ensureTeam);
 
         const creationDate = doc.Configuration?.configuration?.creationDate;
 
@@ -81,7 +81,7 @@ async function getKmsKeyDetails(req, year, month, day, team, ageBucket) {
 
     const allResources = [];
     for await (const doc of cursor) {
-        if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+        if (!(await results.findByAccountId(doc.account_id)).teams.find(t => t === team)) continue;
 
         const cfg = doc.Configuration?.configuration;
         if (!cfg?.creationDate) continue;

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -101,7 +101,7 @@ async function processTlsConfigurations(req, year, month, day) {
             continue;
         }
 
-        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const accountDetails = await accountDetailsResults.findByAccountId(doc.account_id);
         const recs = (accountDetails?.teams || []).map(ensureTeam);
         recs.forEach(rec => rec.totalLBs++);
     }
@@ -110,7 +110,7 @@ async function processTlsConfigurations(req, year, month, day) {
     const elbClassicTotalCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1 });
 
     for await (const doc of elbClassicTotalCursor) {
-        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const accountDetails = await accountDetailsResults.findByAccountId(doc.account_id);
         const recs = (accountDetails?.teams || []).map(ensureTeam);
         recs.forEach(rec => rec.totalLBs++);
     }
@@ -121,7 +121,7 @@ async function processTlsConfigurations(req, year, month, day) {
     for await (const doc of elbV2ListenersCursor) {
         if (!doc.account_id) continue;
 
-        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const accountDetails = await accountDetailsResults.findByAccountId(doc.account_id);
         if (!accountDetails || !accountDetails.teams || !Array.isArray(accountDetails.teams)) continue;
 
         const recs = accountDetails.teams.map(ensureTeam);
@@ -139,7 +139,7 @@ async function processTlsConfigurations(req, year, month, day) {
     const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
     for await (const doc of elbClassicCursor) {
-        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const accountDetails = await accountDetailsResults.findByAccountId(doc.account_id);
         const recs = (accountDetails?.teams || []).map(ensureTeam);
 
         if (doc.Configuration?.ListenerDescriptions) {
@@ -175,7 +175,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
             // Skip NLBs with only TCP/UDP listeners
             if (tcpUdpOnlyNlbs.has(doc.resource_id)) continue;
 
-            if (results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) {
+            if ((await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) {
                 teamLoadBalancers.set(doc.resource_id, doc);
                 const shortId = doc.resource_id.split('/').pop();
                 teamLoadBalancersByShortId.set(shortId, doc);
@@ -228,7 +228,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbClassicCursor) {
-            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
+            if (!(await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) continue;
 
             let hasTLS = false;
             if (doc.Configuration?.ListenerDescriptions) {
@@ -268,7 +268,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const teamLoadBalancersByShortId = new Map();
 
         for await (const doc of elbV2Cursor) {
-            if (results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) {
+            if ((await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) {
                 teamLoadBalancers.set(doc.resource_id, doc);
                 teamLoadBalancersByArn.set(doc.resource_id, doc);
                 const shortId = doc.resource_id.split('/').pop();
@@ -323,7 +323,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbClassicCursor) {
-            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
+            if (!(await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) continue;
 
             if (doc.Configuration?.ListenerDescriptions) {
                 for (const listenerDesc of doc.Configuration.ListenerDescriptions) {
@@ -371,7 +371,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
     const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
     for await (const doc of elbV2Cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const recs = (accountDetails?.teams || []).map(ensureTeam);
         const type = doc.Configuration?.Type || "Unknown";
         recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
@@ -380,7 +380,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
     const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1 });
 
     for await (const doc of elbClassicCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const recs = (accountDetails?.teams || []).map(ensureTeam);
         recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
     }
@@ -397,7 +397,7 @@ async function getLoadBalancerTypeDetails(req, year, month, day, team, type) {
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbClassicCursor) {
-            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
+            if (!(await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) continue;
 
             allResources.push({
                 resourceId: doc.resource_id,
@@ -418,7 +418,7 @@ async function getLoadBalancerTypeDetails(req, year, month, day, team, type) {
         const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbV2Cursor) {
-            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
+            if (!(await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) continue;
 
             const docType = doc.Configuration?.Type;
             if (docType === type) {

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -46,7 +46,7 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
     // Get all NLBs (type="network")
     const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { resource_id: 1, Configuration: 1 });
     for await (const doc of elbV2Cursor) {
-        const type = doc.Configuration?.configuration?.type;
+        const type = doc.Configuration?.Type;
         if (type === "network") {
             nlbArns.add(doc.resource_id);
         }
@@ -55,8 +55,8 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
     // Check which NLBs have TLS listeners
     const listenersCursor = await getElbV2ListenersForDate(req, year, month, day, { Configuration: 1 });
     for await (const doc of listenersCursor) {
-        const protocol = doc.Configuration?.configuration?.protocol;
-        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
+        const protocol = doc.Configuration?.Protocol;
+        const loadBalancerArn = doc.Configuration?.LoadBalancerArn;
 
         if (loadBalancerArn && protocol === "TLS") {
             nlbsWithTlsListeners.add(loadBalancerArn);
@@ -124,7 +124,14 @@ async function processTlsConfigurations(req, year, month, day) {
                 }
 
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                const recs = accountDetails.teams.map(ensureTeam);
+                if (!accountDetails?.teams) {
+                    logger.error('loadbalancers: processTlsConfigurations - missing account details or teams', {
+                        account_id: doc.account_id,
+                        hasAccountDetails: !!accountDetails,
+                        hasTeams: !!accountDetails?.teams
+                    });
+                }
+                const recs = (accountDetails?.teams || []).map(ensureTeam);
                 recs.forEach(rec => rec.totalLBs++);
             } catch (err) {
                 logger.warn('loadbalancers: processTlsConfigurations - error processing ELB v2 doc', {
@@ -158,7 +165,14 @@ async function processTlsConfigurations(req, year, month, day) {
             classicCount++;
             try {
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                const recs = accountDetails.teams.map(ensureTeam);
+                if (!accountDetails?.teams) {
+                    logger.error('loadbalancers: processTlsConfigurations - missing account details or teams for Classic ELB', {
+                        account_id: doc.account_id,
+                        hasAccountDetails: !!accountDetails,
+                        hasTeams: !!accountDetails?.teams
+                    });
+                }
+                const recs = (accountDetails?.teams || []).map(ensureTeam);
                 recs.forEach(rec => rec.totalLBs++);
             } catch (err) {
                 logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB', {
@@ -193,11 +207,11 @@ async function processTlsConfigurations(req, year, month, day) {
 
                 const recs = accountDetails.teams.map(ensureTeam);
 
-                if (doc.Configuration?.configuration) {
-                    const protocol = doc.Configuration.configuration.protocol;
+                if (doc.Configuration) {
+                    const protocol = doc.Configuration.Protocol;
                     if (protocol === "HTTPS" || protocol === "TLS") {
                         httpsListenerCount++;
-                        const policy = doc.Configuration.configuration.sslPolicy || "Unknown";
+                        const policy = doc.Configuration.SslPolicy || "Unknown";
                         recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
                     }
                 }
@@ -219,13 +233,20 @@ async function processTlsConfigurations(req, year, month, day) {
         for await (const doc of elbClassicCursor) {
             try {
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                const recs = accountDetails.teams.map(ensureTeam);
+                if (!accountDetails?.teams) {
+                    logger.error('loadbalancers: processTlsConfigurations - missing account details or teams for Classic ELB listeners', {
+                        account_id: doc.account_id,
+                        hasAccountDetails: !!accountDetails,
+                        hasTeams: !!accountDetails?.teams
+                    });
+                }
+                const recs = (accountDetails?.teams || []).map(ensureTeam);
 
-                if (doc.Configuration?.configuration?.listenerDescriptions) {
-                    for (const listenerDesc of doc.Configuration.configuration.listenerDescriptions) {
-                        const listener = listenerDesc.listener;
-                        if (listener?.protocol === "HTTPS" || listener?.protocol === "SSL") {
-                            const policy = listenerDesc.policyNames?.[0] || "Classic-Default";
+                if (doc.Configuration?.ListenerDescriptions) {
+                    for (const listenerDesc of doc.Configuration.ListenerDescriptions) {
+                        const listener = listenerDesc.Listener;
+                        if (listener?.Protocol === "HTTPS" || listener?.Protocol === "SSL") {
+                            const policy = listenerDesc.PolicyNames?.[0] || "Classic-Default";
                             recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
                         }
                     }
@@ -269,7 +290,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
             // Skip NLBs with only TCP/UDP listeners
             if (tcpUdpOnlyNlbs.has(doc.resource_id)) continue;
 
-            if (!!results.findByAccountId(doc.account_id).teams.find(t => t === team)) {
+            if (results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) {
                 teamLoadBalancers.set(doc.resource_id, doc);
                 const shortId = doc.resource_id.split('/').pop();
                 teamLoadBalancersByShortId.set(shortId, doc);
@@ -281,10 +302,10 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { Configuration: 1 });
 
         for await (const doc of elbV2ListenersCursor) {
-            const protocol = doc.Configuration?.configuration?.protocol;
+            const protocol = doc.Configuration?.Protocol;
 
             if (protocol === "HTTPS" || protocol === "TLS") {
-                const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
+                const loadBalancerArn = doc.Configuration?.LoadBalancerArn;
 
                 if (loadBalancerArn) {
                     tlsLoadBalancerArns.add(loadBalancerArn);
@@ -302,17 +323,17 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
             if (!hasExactMatch && !hasShortIdMatch) {
                 allResources.push({
                     resourceId: resourceId,
-                    shortName: lbDoc.Configuration?.configuration?.loadBalancerName || resourceId,
-                    type: lbDoc.Configuration?.configuration?.type || "Unknown",
-                    scheme: lbDoc.Configuration?.configuration?.scheme || "Unknown",
+                    shortName: lbDoc.Configuration?.LoadBalancerName || resourceId,
+                    type: lbDoc.Configuration?.Type || "Unknown",
+                    scheme: lbDoc.Configuration?.Scheme || "Unknown",
                     accountId: lbDoc.account_id,
                     tlsPolicy: "NO CERTS",
                     details: {
-                        dnsName: lbDoc.Configuration?.configuration?.dNSName,
-                        availabilityZones: lbDoc.Configuration?.configuration?.availabilityZones?.map(az => az.zoneName).join(", "),
-                        securityGroups: lbDoc.Configuration?.configuration?.securityGroups?.join(", "),
-                        vpcId: lbDoc.Configuration?.configuration?.vpcId,
-                        state: lbDoc.Configuration?.configuration?.state?.code
+                        dnsName: lbDoc.Configuration?.DNSName,
+                        availabilityZones: lbDoc.Configuration?.AvailabilityZones?.map(az => az.ZoneName).join(", "),
+                        securityGroups: lbDoc.Configuration?.SecurityGroups?.join(", "),
+                        vpcId: lbDoc.Configuration?.VpcId,
+                        state: lbDoc.Configuration?.State?.Code
                     }
                 });
             }
@@ -322,13 +343,13 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbClassicCursor) {
-            if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
 
             let hasTLS = false;
-            if (doc.Configuration?.configuration?.listenerDescriptions) {
-                for (const listenerDesc of doc.Configuration.configuration.listenerDescriptions) {
-                    const listener = listenerDesc.listener;
-                    if (listener?.protocol === "HTTPS" || listener?.protocol === "SSL") {
+            if (doc.Configuration?.ListenerDescriptions) {
+                for (const listenerDesc of doc.Configuration.ListenerDescriptions) {
+                    const listener = listenerDesc.Listener;
+                    if (listener?.Protocol === "HTTPS" || listener?.Protocol === "SSL") {
                         hasTLS = true;
                         break;
                     }
@@ -338,16 +359,16 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
             if (!hasTLS) {
                 allResources.push({
                     resourceId: doc.resource_id,
-                    shortName: doc.Configuration?.configuration?.loadBalancerName || doc.resource_id,
+                    shortName: doc.Configuration?.LoadBalancerName || doc.resource_id,
                     type: "classic",
-                    scheme: doc.Configuration?.configuration?.scheme || "Unknown",
+                    scheme: doc.Configuration?.Scheme || "Unknown",
                     accountId: doc.account_id,
                     tlsPolicy: "NO CERTS",
                     details: {
-                        dnsName: doc.Configuration?.configuration?.dnsName,
-                        availabilityZones: doc.Configuration?.configuration?.availabilityZones?.join(", "),
-                        securityGroups: doc.Configuration?.configuration?.securityGroups?.join(", "),
-                        vpcId: doc.Configuration?.configuration?.vpcId,
+                        dnsName: doc.Configuration?.DNSName,
+                        availabilityZones: doc.Configuration?.AvailabilityZones?.join(", "),
+                        securityGroups: doc.Configuration?.SecurityGroups?.join(", "),
+                        vpcId: doc.Configuration?.VpcId,
                         state: "active"
                     }
                 });
@@ -362,7 +383,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const teamLoadBalancersByShortId = new Map();
 
         for await (const doc of elbV2Cursor) {
-            if (!!results.findByAccountId(doc.account_id).teams.find(t => t === team)) {
+            if (results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) {
                 teamLoadBalancers.set(doc.resource_id, doc);
                 teamLoadBalancersByArn.set(doc.resource_id, doc);
                 const shortId = doc.resource_id.split('/').pop();
@@ -373,11 +394,11 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
         for await (const doc of elbV2ListenersCursor) {
-            if (doc.Configuration?.configuration) {
-                const protocol = doc.Configuration.configuration.protocol;
+            if (doc.Configuration) {
+                const protocol = doc.Configuration.Protocol;
                 if (protocol === "HTTPS" || protocol === "TLS") {
-                    const policy = doc.Configuration.configuration.sslPolicy || "Unknown";
-                    const loadBalancerArn = doc.Configuration.configuration.loadBalancerArn;
+                    const policy = doc.Configuration.SslPolicy || "Unknown";
+                    const loadBalancerArn = doc.Configuration.LoadBalancerArn;
 
                     if (policy === tlsVersion && loadBalancerArn) {
                         let lbDoc = null;
@@ -394,17 +415,17 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
                         if (lbDoc) {
                             allResources.push({
                                 resourceId: loadBalancerArn,
-                                shortName: lbDoc.Configuration?.configuration?.loadBalancerName || loadBalancerArn,
-                                type: lbDoc.Configuration?.configuration?.type || "Unknown",
-                                scheme: lbDoc.Configuration?.configuration?.scheme || "Unknown",
+                                shortName: lbDoc.Configuration?.LoadBalancerName || loadBalancerArn,
+                                type: lbDoc.Configuration?.Type || "Unknown",
+                                scheme: lbDoc.Configuration?.Scheme || "Unknown",
                                 accountId: doc.account_id,
                                 tlsPolicy: policy,
                                 details: {
-                                    dnsName: lbDoc.Configuration?.configuration?.dNSName,
-                                    availabilityZones: lbDoc.Configuration?.configuration?.availabilityZones?.map(az => az.zoneName).join(", "),
-                                    securityGroups: lbDoc.Configuration?.configuration?.securityGroups?.join(", "),
-                                    vpcId: lbDoc.Configuration?.configuration?.vpcId,
-                                    state: lbDoc.Configuration?.configuration?.state?.code
+                                    dnsName: lbDoc.Configuration?.DNSName,
+                                    availabilityZones: lbDoc.Configuration?.AvailabilityZones?.map(az => az.ZoneName).join(", "),
+                                    securityGroups: lbDoc.Configuration?.SecurityGroups?.join(", "),
+                                    vpcId: lbDoc.Configuration?.VpcId,
+                                    state: lbDoc.Configuration?.State?.Code
                                 }
                             });
                         }
@@ -417,26 +438,26 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbClassicCursor) {
-            if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
 
-            if (doc.Configuration?.configuration?.listenerDescriptions) {
-                for (const listenerDesc of doc.Configuration.configuration.listenerDescriptions) {
-                    const listener = listenerDesc.listener;
-                    if (listener?.protocol === "HTTPS" || listener?.protocol === "SSL") {
-                        const policy = listenerDesc.policyNames?.[0] || "Classic-Default";
+            if (doc.Configuration?.ListenerDescriptions) {
+                for (const listenerDesc of doc.Configuration.ListenerDescriptions) {
+                    const listener = listenerDesc.Listener;
+                    if (listener?.Protocol === "HTTPS" || listener?.Protocol === "SSL") {
+                        const policy = listenerDesc.PolicyNames?.[0] || "Classic-Default";
                         if (policy === tlsVersion) {
                             allResources.push({
                                 resourceId: doc.resource_id,
-                                shortName: doc.Configuration?.configuration?.loadBalancerName || doc.resource_id,
+                                shortName: doc.Configuration?.LoadBalancerName || doc.resource_id,
                                 type: "classic",
-                                scheme: doc.Configuration?.configuration?.scheme || "Unknown",
+                                scheme: doc.Configuration?.Scheme || "Unknown",
                                 accountId: doc.account_id,
                                 tlsPolicy: policy,
                                 details: {
-                                    dnsName: doc.Configuration?.configuration?.dnsName,
-                                    availabilityZones: doc.Configuration?.configuration?.availabilityZones?.join(", "),
-                                    securityGroups: doc.Configuration?.configuration?.securityGroups?.join(", "),
-                                    vpcId: doc.Configuration?.configuration?.vpcId,
+                                    dnsName: doc.Configuration?.DNSName,
+                                    availabilityZones: doc.Configuration?.AvailabilityZones?.join(", "),
+                                    securityGroups: doc.Configuration?.SecurityGroups?.join(", "),
+                                    vpcId: doc.Configuration?.VpcId,
                                     state: "active"
                                 }
                             });
@@ -475,13 +496,20 @@ async function processLoadBalancerTypes(req, year, month, day) {
             logger.debug('loadbalancers: processLoadBalancerTypes - first ELB v2 doc sample', {
                 account_id: doc.account_id,
                 hasConfiguration: !!doc.Configuration,
-                hasNestedConfig: !!doc.Configuration?.configuration,
-                type: doc.Configuration?.configuration?.type
+                type: doc.Configuration?.Type
             });
         }
         try {
-            const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
-            const type = doc.Configuration?.configuration?.type || "Unknown";
+            const accountDetails = results.findByAccountId(doc.account_id);
+            if (!accountDetails?.teams) {
+                logger.error('loadbalancers: processLoadBalancerTypes - missing account details or teams', {
+                    account_id: doc.account_id,
+                    hasAccountDetails: !!accountDetails,
+                    hasTeams: !!accountDetails?.teams
+                });
+            }
+            const recs = (accountDetails?.teams || []).map(ensureTeam);
+            const type = doc.Configuration?.Type || "Unknown";
             recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
         } catch (err) {
             logger.warn('loadbalancers: processLoadBalancerTypes - error processing ELB v2', {
@@ -497,7 +525,15 @@ async function processLoadBalancerTypes(req, year, month, day) {
     for await (const doc of elbClassicCursor) {
         classicCount++;
         try {
-            const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+            const accountDetails = results.findByAccountId(doc.account_id);
+            if (!accountDetails?.teams) {
+                logger.error('loadbalancers: processLoadBalancerTypes - missing account details or teams for Classic ELB', {
+                    account_id: doc.account_id,
+                    hasAccountDetails: !!accountDetails,
+                    hasTeams: !!accountDetails?.teams
+                });
+            }
+            const recs = (accountDetails?.teams || []).map(ensureTeam);
             recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
         } catch (err) {
             logger.warn('loadbalancers: processLoadBalancerTypes - error processing Classic ELB', {
@@ -525,20 +561,20 @@ async function getLoadBalancerTypeDetails(req, year, month, day, team, type) {
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbClassicCursor) {
-            if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
 
             allResources.push({
                 resourceId: doc.resource_id,
-                shortName: doc.Configuration?.configuration?.loadBalancerName || doc.resource_id,
+                shortName: doc.Configuration?.LoadBalancerName || doc.resource_id,
                 type: "classic",
-                scheme: doc.Configuration?.configuration?.scheme || "Unknown",
+                scheme: doc.Configuration?.Scheme || "Unknown",
                 accountId: doc.account_id,
                 details: {
-                    dnsName: doc.Configuration?.configuration?.dnsName,
-                    availabilityZones: doc.Configuration?.configuration?.availabilityZones?.join(", "),
-                    securityGroups: doc.Configuration?.configuration?.securityGroups?.join(", "),
-                    vpcId: doc.Configuration?.configuration?.vpcId,
-                    createdTime: doc.Configuration?.configuration?.createdTime
+                    dnsName: doc.Configuration?.DNSName,
+                    availabilityZones: doc.Configuration?.AvailabilityZones?.join(", "),
+                    securityGroups: doc.Configuration?.SecurityGroups?.join(", "),
+                    vpcId: doc.Configuration?.VpcId,
+                    createdTime: doc.Configuration?.CreatedTime
                 }
             });
         }
@@ -546,28 +582,28 @@ async function getLoadBalancerTypeDetails(req, year, month, day, team, type) {
         const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, resource_id: 1, Configuration: 1 });
 
         for await (const doc of elbV2Cursor) {
-            if (!results.findByAccountId(doc.account_id).teams.find(t => t === team)) continue;
+            if (!results.findByAccountId(doc.account_id)?.teams?.find(t => t === team)) continue;
 
-            const docType = doc.Configuration?.configuration?.type;
+            const docType = doc.Configuration?.Type;
             if (docType === type) {
                 allResources.push({
                     resourceId: doc.resource_id,
-                    shortName: doc.Configuration?.configuration?.loadBalancerName || doc.resource_id,
+                    shortName: doc.Configuration?.LoadBalancerName || doc.resource_id,
                     type: (() => {
                         if (docType === "application") return "ALB";
                         if (docType === "network") return "NLB";
                         if (docType === "classic") return "Classic";
                         return docType;
                     })(),
-                    scheme: doc.Configuration?.configuration?.scheme || "Unknown",
+                    scheme: doc.Configuration?.Scheme || "Unknown",
                     accountId: doc.account_id,
                     details: {
-                        dnsName: doc.Configuration?.configuration?.dNSName,
-                        availabilityZones: doc.Configuration?.configuration?.availabilityZones?.map(az => az.zoneName).join(", "),
-                        securityGroups: doc.Configuration?.configuration?.securityGroups?.join(", "),
-                        vpcId: doc.Configuration?.configuration?.vpcId,
-                        state: doc.Configuration?.configuration?.state?.code,
-                        createdTime: doc.Configuration?.configuration?.createdTime
+                        dnsName: doc.Configuration?.DNSName,
+                        availabilityZones: doc.Configuration?.AvailabilityZones?.map(az => az.ZoneName).join(", "),
+                        securityGroups: doc.Configuration?.SecurityGroups?.join(", "),
+                        vpcId: doc.Configuration?.VpcId,
+                        state: doc.Configuration?.State?.Code,
+                        createdTime: doc.Configuration?.CreatedTime
                     }
                 });
             }

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -1,5 +1,17 @@
 const logger = require('../../libs/logger');
 
+/**
+ * Redact account ID for logging - shows first 4 digits only
+ * @param {string} accountId - AWS account ID
+ * @returns {string} Redacted account ID (e.g., "1234********")
+ */
+function redactAccountId(accountId) {
+    if (!accountId) return 'unknown';
+    const str = String(accountId);
+    if (str.length <= 4) return str;
+    return str.substring(0, 4) + '*'.repeat(str.length - 4);
+}
+
 async function getLatestElbDate(req) {
     logger.debug('loadbalancers: getLatestElbDate - fetching latest date from elb_v2');
     const result = await req.collection("elb_v2").findOne({}, {
@@ -111,7 +123,7 @@ async function processTlsConfigurations(req, year, month, day) {
             if (!firstDoc) {
                 firstDoc = doc;
                 logger.debug('loadbalancers: processTlsConfigurations - first ELB v2 doc sample', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     resource_id: doc.resource_id,
                     hasConfiguration: !!doc.Configuration
                 });
@@ -126,16 +138,18 @@ async function processTlsConfigurations(req, year, month, day) {
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
                 if (!accountDetails?.teams) {
                     logger.error('loadbalancers: processTlsConfigurations - missing account details or teams', {
-                        account_id: doc.account_id,
+                        account_id: redactAccountId(doc.account_id),
                         hasAccountDetails: !!accountDetails,
-                        hasTeams: !!accountDetails?.teams
+                        hasTeams: !!accountDetails?.teams,
+                        accountDetailsKeys: accountDetails ? Object.keys(accountDetails) : [],
+                        teamsType: accountDetails?.teams === undefined ? 'undefined' : (accountDetails?.teams === null ? 'null' : typeof accountDetails?.teams)
                     });
                 }
                 const recs = (accountDetails?.teams || []).map(ensureTeam);
                 recs.forEach(rec => rec.totalLBs++);
             } catch (err) {
                 logger.warn('loadbalancers: processTlsConfigurations - error processing ELB v2 doc', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     error: err.message
                 });
             }
@@ -167,7 +181,7 @@ async function processTlsConfigurations(req, year, month, day) {
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
                 if (!accountDetails?.teams) {
                     logger.error('loadbalancers: processTlsConfigurations - missing account details or teams for Classic ELB', {
-                        account_id: doc.account_id,
+                        account_id: redactAccountId(doc.account_id),
                         hasAccountDetails: !!accountDetails,
                         hasTeams: !!accountDetails?.teams
                     });
@@ -176,7 +190,7 @@ async function processTlsConfigurations(req, year, month, day) {
                 recs.forEach(rec => rec.totalLBs++);
             } catch (err) {
                 logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     error: err.message
                 });
             }
@@ -192,7 +206,7 @@ async function processTlsConfigurations(req, year, month, day) {
             if (!firstListenerDoc) {
                 firstListenerDoc = doc;
                 logger.debug('loadbalancers: processTlsConfigurations - first listener doc sample', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     hasConfiguration: !!doc.Configuration,
                     hasNestedConfig: !!doc.Configuration?.configuration,
                     protocol: doc.Configuration?.configuration?.protocol,
@@ -217,7 +231,7 @@ async function processTlsConfigurations(req, year, month, day) {
                 }
             } catch (err) {
                 logger.warn('loadbalancers: processTlsConfigurations - error processing listener', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     error: err.message
                 });
             }
@@ -235,7 +249,7 @@ async function processTlsConfigurations(req, year, month, day) {
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
                 if (!accountDetails?.teams) {
                     logger.error('loadbalancers: processTlsConfigurations - missing account details or teams for Classic ELB listeners', {
-                        account_id: doc.account_id,
+                        account_id: redactAccountId(doc.account_id),
                         hasAccountDetails: !!accountDetails,
                         hasTeams: !!accountDetails?.teams
                     });
@@ -253,7 +267,7 @@ async function processTlsConfigurations(req, year, month, day) {
                 }
             } catch (err) {
                 logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB listeners', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     error: err.message
                 });
             }
@@ -494,7 +508,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
         if (!firstDoc) {
             firstDoc = doc;
             logger.debug('loadbalancers: processLoadBalancerTypes - first ELB v2 doc sample', {
-                account_id: doc.account_id,
+                account_id: redactAccountId(doc.account_id),
                 hasConfiguration: !!doc.Configuration,
                 type: doc.Configuration?.Type
             });
@@ -503,7 +517,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
             const accountDetails = results.findByAccountId(doc.account_id);
             if (!accountDetails?.teams) {
                 logger.error('loadbalancers: processLoadBalancerTypes - missing account details or teams', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     hasAccountDetails: !!accountDetails,
                     hasTeams: !!accountDetails?.teams
                 });
@@ -513,7 +527,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
             recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
         } catch (err) {
             logger.warn('loadbalancers: processLoadBalancerTypes - error processing ELB v2', {
-                account_id: doc.account_id,
+                account_id: redactAccountId(doc.account_id),
                 error: err.message
             });
         }
@@ -528,7 +542,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
             const accountDetails = results.findByAccountId(doc.account_id);
             if (!accountDetails?.teams) {
                 logger.error('loadbalancers: processLoadBalancerTypes - missing account details or teams for Classic ELB', {
-                    account_id: doc.account_id,
+                    account_id: redactAccountId(doc.account_id),
                     hasAccountDetails: !!accountDetails,
                     hasTeams: !!accountDetails?.teams
                 });
@@ -537,7 +551,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
             recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
         } catch (err) {
             logger.warn('loadbalancers: processLoadBalancerTypes - error processing Classic ELB', {
-                account_id: doc.account_id,
+                account_id: redactAccountId(doc.account_id),
                 error: err.message
             });
         }

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -1,8 +1,13 @@
+const logger = require('../../libs/logger');
+
 async function getLatestElbDate(req) {
-    return await req.collection("elb_v2").findOne({}, {
+    logger.debug('loadbalancers: getLatestElbDate - fetching latest date from elb_v2');
+    const result = await req.collection("elb_v2").findOne({}, {
         projection: { year: 1, month: 1, day: 1 },
         sort: { year: -1, month: -1, day: -1 }
     });
+    logger.debug('loadbalancers: getLatestElbDate - result', { result });
+    return result;
 }
 
 async function getElbV2ForDate(req, year, month, day, projection = null) {
@@ -77,8 +82,11 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
 }
 
 async function processTlsConfigurations(req, year, month, day) {
+    logger.info('loadbalancers: processTlsConfigurations - starting', { year, month, day });
     const teamTls = new Map();
     let accountDetailsResults;
+    let elbV2Count = 0;
+    let skippedTcpUdpCount = 0;
 
     const ensureTeam = t => {
         if (!teamTls.has(t))
@@ -88,28 +96,55 @@ async function processTlsConfigurations(req, year, month, day) {
 
     try {
         accountDetailsResults = await req.getDetailsForAllAccounts();
+        logger.debug('loadbalancers: processTlsConfigurations - got account details resolver');
 
         // Get NLBs with only TCP/UDP listeners to exclude from TLS evaluation
         const tcpUdpOnlyNlbs = await getNlbsWithOnlyTcpUdpListeners(req, year, month, day);
+        logger.debug('loadbalancers: processTlsConfigurations - TCP/UDP only NLBs to exclude', { count: tcpUdpOnlyNlbs.size });
 
         // Count total ELB v2 (excluding TCP/UDP-only NLBs)
         const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, resource_id: 1 });
 
+        let firstDoc = null;
         for await (const doc of elbV2Cursor) {
+            elbV2Count++;
+            if (!firstDoc) {
+                firstDoc = doc;
+                logger.debug('loadbalancers: processTlsConfigurations - first ELB v2 doc sample', {
+                    account_id: doc.account_id,
+                    resource_id: doc.resource_id,
+                    hasConfiguration: !!doc.Configuration
+                });
+            }
             try {
                 // Skip NLBs with only TCP/UDP listeners
-                if (tcpUdpOnlyNlbs.has(doc.resource_id)) continue;
+                if (tcpUdpOnlyNlbs.has(doc.resource_id)) {
+                    skippedTcpUdpCount++;
+                    continue;
+                }
 
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
                 const recs = accountDetails.teams.map(ensureTeam);
                 recs.forEach(rec => rec.totalLBs++);
             } catch (err) {
-                // Skip documents with invalid account_id
+                logger.warn('loadbalancers: processTlsConfigurations - error processing ELB v2 doc', {
+                    account_id: doc.account_id,
+                    error: err.message
+                });
             }
         }
+        logger.info('loadbalancers: processTlsConfigurations - processed ELB v2 documents', {
+            total: elbV2Count,
+            skippedTcpUdp: skippedTcpUdpCount
+        });
     } catch (err) {
+        logger.error('loadbalancers: processTlsConfigurations - error in ELB v2 processing', { error: err.message, stack: err.stack });
         throw err;
     }
+
+    let classicCount = 0;
+    let listenerCount = 0;
+    let httpsListenerCount = 0;
 
     try {
         // Count total Classic ELBs
@@ -120,19 +155,36 @@ async function processTlsConfigurations(req, year, month, day) {
         }
 
         for await (const doc of elbClassicTotalCursor) {
+            classicCount++;
             try {
                 const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
                 const recs = accountDetails.teams.map(ensureTeam);
                 recs.forEach(rec => rec.totalLBs++);
             } catch (err) {
-                // Skip documents with invalid account_id
+                logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB', {
+                    account_id: doc.account_id,
+                    error: err.message
+                });
             }
         }
+        logger.debug('loadbalancers: processTlsConfigurations - processed Classic ELBs', { count: classicCount });
 
         // Process ELB v2 Listeners
         const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
+        let firstListenerDoc = null;
         for await (const doc of elbV2ListenersCursor) {
+            listenerCount++;
+            if (!firstListenerDoc) {
+                firstListenerDoc = doc;
+                logger.debug('loadbalancers: processTlsConfigurations - first listener doc sample', {
+                    account_id: doc.account_id,
+                    hasConfiguration: !!doc.Configuration,
+                    hasNestedConfig: !!doc.Configuration?.configuration,
+                    protocol: doc.Configuration?.configuration?.protocol,
+                    sslPolicy: doc.Configuration?.configuration?.sslPolicy
+                });
+            }
             try {
                 if (!doc.account_id) continue;
 
@@ -144,14 +196,22 @@ async function processTlsConfigurations(req, year, month, day) {
                 if (doc.Configuration?.configuration) {
                     const protocol = doc.Configuration.configuration.protocol;
                     if (protocol === "HTTPS" || protocol === "TLS") {
+                        httpsListenerCount++;
                         const policy = doc.Configuration.configuration.sslPolicy || "Unknown";
                         recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
                     }
                 }
             } catch (err) {
-                // Skip documents with errors
+                logger.warn('loadbalancers: processTlsConfigurations - error processing listener', {
+                    account_id: doc.account_id,
+                    error: err.message
+                });
             }
         }
+        logger.info('loadbalancers: processTlsConfigurations - processed listeners', {
+            total: listenerCount,
+            httpsOrTls: httpsListenerCount
+        });
 
         // Process Classic ELBs
         const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
@@ -171,13 +231,21 @@ async function processTlsConfigurations(req, year, month, day) {
                     }
                 }
             } catch (err) {
-                // Skip documents with errors
+                logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB listeners', {
+                    account_id: doc.account_id,
+                    error: err.message
+                });
             }
         }
 
     } catch (err) {
-        // Continue with processing
+        logger.error('loadbalancers: processTlsConfigurations - error in processing', { error: err.message });
     }
+
+    logger.info('loadbalancers: processTlsConfigurations - completed', {
+        teamCount: teamTls.size,
+        teams: Array.from(teamTls.keys())
+    });
 
     return teamTls;
 }
@@ -384,7 +452,10 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
 }
 
 async function processLoadBalancerTypes(req, year, month, day) {
+    logger.info('loadbalancers: processLoadBalancerTypes - starting', { year, month, day });
     const teamTypes = new Map();
+    let elbV2Count = 0;
+    let classicCount = 0;
 
     const ensureTeam = t => {
         if (!teamTypes.has(t))
@@ -396,18 +467,51 @@ async function processLoadBalancerTypes(req, year, month, day) {
 
     const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
+    let firstDoc = null;
     for await (const doc of elbV2Cursor) {
-        const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
-        const type = doc.Configuration?.configuration?.type || "Unknown";
-        recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
+        elbV2Count++;
+        if (!firstDoc) {
+            firstDoc = doc;
+            logger.debug('loadbalancers: processLoadBalancerTypes - first ELB v2 doc sample', {
+                account_id: doc.account_id,
+                hasConfiguration: !!doc.Configuration,
+                hasNestedConfig: !!doc.Configuration?.configuration,
+                type: doc.Configuration?.configuration?.type
+            });
+        }
+        try {
+            const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+            const type = doc.Configuration?.configuration?.type || "Unknown";
+            recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
+        } catch (err) {
+            logger.warn('loadbalancers: processLoadBalancerTypes - error processing ELB v2', {
+                account_id: doc.account_id,
+                error: err.message
+            });
+        }
     }
+    logger.debug('loadbalancers: processLoadBalancerTypes - processed ELB v2', { count: elbV2Count });
 
     const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1 });
 
     for await (const doc of elbClassicCursor) {
-        const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
-        recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
+        classicCount++;
+        try {
+            const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+            recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
+        } catch (err) {
+            logger.warn('loadbalancers: processLoadBalancerTypes - error processing Classic ELB', {
+                account_id: doc.account_id,
+                error: err.message
+            });
+        }
     }
+    logger.debug('loadbalancers: processLoadBalancerTypes - processed Classic ELBs', { count: classicCount });
+
+    logger.info('loadbalancers: processLoadBalancerTypes - completed', {
+        teamCount: teamTypes.size,
+        teams: Array.from(teamTypes.keys())
+    });
 
     return teamTypes;
 }

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -50,8 +50,8 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
     // Check which NLBs have TLS listeners
     const listenersCursor = await getElbV2ListenersForDate(req, year, month, day, { Configuration: 1 });
     for await (const doc of listenersCursor) {
-        const protocol = doc.Configuration?.configuration?.Protocol;
-        const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
+        const protocol = doc.Configuration?.configuration?.protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
 
         if (loadBalancerArn && protocol === "TLS") {
             nlbsWithTlsListeners.add(loadBalancerArn);
@@ -142,9 +142,9 @@ async function processTlsConfigurations(req, year, month, day) {
                 const recs = accountDetails.teams.map(ensureTeam);
 
                 if (doc.Configuration?.configuration) {
-                    const protocol = doc.Configuration.configuration.Protocol;
+                    const protocol = doc.Configuration.configuration.protocol;
                     if (protocol === "HTTPS" || protocol === "TLS") {
-                        const policy = doc.Configuration.configuration.SslPolicy || "Unknown";
+                        const policy = doc.Configuration.configuration.sslPolicy || "Unknown";
                         recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
                     }
                 }
@@ -213,10 +213,10 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { Configuration: 1 });
 
         for await (const doc of elbV2ListenersCursor) {
-            const protocol = doc.Configuration?.configuration?.Protocol;
+            const protocol = doc.Configuration?.configuration?.protocol;
 
             if (protocol === "HTTPS" || protocol === "TLS") {
-                const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
+                const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
 
                 if (loadBalancerArn) {
                     tlsLoadBalancerArns.add(loadBalancerArn);
@@ -306,10 +306,10 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
 
         for await (const doc of elbV2ListenersCursor) {
             if (doc.Configuration?.configuration) {
-                const protocol = doc.Configuration.configuration.Protocol;
+                const protocol = doc.Configuration.configuration.protocol;
                 if (protocol === "HTTPS" || protocol === "TLS") {
-                    const policy = doc.Configuration.configuration.SslPolicy || "Unknown";
-                    const loadBalancerArn = doc.Configuration.configuration.LoadBalancerArn;
+                    const policy = doc.Configuration.configuration.sslPolicy || "Unknown";
+                    const loadBalancerArn = doc.Configuration.configuration.loadBalancerArn;
 
                     if (policy === tlsVersion && loadBalancerArn) {
                         let lbDoc = null;

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -1,24 +1,8 @@
-const logger = require('../../libs/logger');
-
-/**
- * Redact account ID for logging - shows first 4 digits only
- * @param {string} accountId - AWS account ID
- * @returns {string} Redacted account ID (e.g., "1234********")
- */
-function redactAccountId(accountId) {
-    if (!accountId) return 'unknown';
-    const str = String(accountId);
-    if (str.length <= 4) return str;
-    return str.substring(0, 4) + '*'.repeat(str.length - 4);
-}
-
 async function getLatestElbDate(req) {
-    logger.debug('loadbalancers: getLatestElbDate - fetching latest date from elb_v2');
     const result = await req.collection("elb_v2").findOne({}, {
         projection: { year: 1, month: 1, day: 1 },
         sort: { year: -1, month: -1, day: -1 }
     });
-    logger.debug('loadbalancers: getLatestElbDate - result', { result });
     return result;
 }
 
@@ -94,11 +78,8 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
 }
 
 async function processTlsConfigurations(req, year, month, day) {
-    logger.info('loadbalancers: processTlsConfigurations - starting', { year, month, day });
     const teamTls = new Map();
     let accountDetailsResults;
-    let elbV2Count = 0;
-    let skippedTcpUdpCount = 0;
 
     const ensureTeam = t => {
         if (!teamTls.has(t))
@@ -106,181 +87,71 @@ async function processTlsConfigurations(req, year, month, day) {
         return teamTls.get(t);
     };
 
-    try {
-        accountDetailsResults = await req.getDetailsForAllAccounts();
-        logger.debug('loadbalancers: processTlsConfigurations - got account details resolver');
+    accountDetailsResults = await req.getDetailsForAllAccounts();
 
-        // Get NLBs with only TCP/UDP listeners to exclude from TLS evaluation
-        const tcpUdpOnlyNlbs = await getNlbsWithOnlyTcpUdpListeners(req, year, month, day);
-        logger.debug('loadbalancers: processTlsConfigurations - TCP/UDP only NLBs to exclude', { count: tcpUdpOnlyNlbs.size });
+    // Get NLBs with only TCP/UDP listeners to exclude from TLS evaluation
+    const tcpUdpOnlyNlbs = await getNlbsWithOnlyTcpUdpListeners(req, year, month, day);
 
-        // Count total ELB v2 (excluding TCP/UDP-only NLBs)
-        const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, resource_id: 1 });
+    // Count total ELB v2 (excluding TCP/UDP-only NLBs)
+    const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, resource_id: 1 });
 
-        let firstDoc = null;
-        for await (const doc of elbV2Cursor) {
-            elbV2Count++;
-            if (!firstDoc) {
-                firstDoc = doc;
-                logger.debug('loadbalancers: processTlsConfigurations - first ELB v2 doc sample', {
-                    account_id: redactAccountId(doc.account_id),
-                    resource_id: doc.resource_id,
-                    hasConfiguration: !!doc.Configuration
-                });
-            }
-            try {
-                // Skip NLBs with only TCP/UDP listeners
-                if (tcpUdpOnlyNlbs.has(doc.resource_id)) {
-                    skippedTcpUdpCount++;
-                    continue;
-                }
-
-                const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                if (!accountDetails?.teams) {
-                    logger.error('loadbalancers: processTlsConfigurations - missing account details or teams', {
-                        account_id: redactAccountId(doc.account_id),
-                        hasAccountDetails: !!accountDetails,
-                        hasTeams: !!accountDetails?.teams,
-                        accountDetailsKeys: accountDetails ? Object.keys(accountDetails) : [],
-                        teamsType: accountDetails?.teams === undefined ? 'undefined' : (accountDetails?.teams === null ? 'null' : typeof accountDetails?.teams)
-                    });
-                }
-                const recs = (accountDetails?.teams || []).map(ensureTeam);
-                recs.forEach(rec => rec.totalLBs++);
-            } catch (err) {
-                logger.warn('loadbalancers: processTlsConfigurations - error processing ELB v2 doc', {
-                    account_id: redactAccountId(doc.account_id),
-                    error: err.message
-                });
-            }
+    for await (const doc of elbV2Cursor) {
+        // Skip NLBs with only TCP/UDP listeners
+        if (tcpUdpOnlyNlbs.has(doc.resource_id)) {
+            continue;
         }
-        logger.info('loadbalancers: processTlsConfigurations - processed ELB v2 documents', {
-            total: elbV2Count,
-            skippedTcpUdp: skippedTcpUdpCount
-        });
-    } catch (err) {
-        logger.error('loadbalancers: processTlsConfigurations - error in ELB v2 processing', { error: err.message, stack: err.stack });
-        throw err;
+
+        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const recs = (accountDetails?.teams || []).map(ensureTeam);
+        recs.forEach(rec => rec.totalLBs++);
     }
 
-    let classicCount = 0;
-    let listenerCount = 0;
-    let httpsListenerCount = 0;
+    // Count total Classic ELBs
+    const elbClassicTotalCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1 });
 
-    try {
-        // Count total Classic ELBs
-        const elbClassicTotalCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1 });
-
-        if (!accountDetailsResults) {
-            throw new Error('Account details not available');
-        }
-
-        for await (const doc of elbClassicTotalCursor) {
-            classicCount++;
-            try {
-                const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                if (!accountDetails?.teams) {
-                    logger.error('loadbalancers: processTlsConfigurations - missing account details or teams for Classic ELB', {
-                        account_id: redactAccountId(doc.account_id),
-                        hasAccountDetails: !!accountDetails,
-                        hasTeams: !!accountDetails?.teams
-                    });
-                }
-                const recs = (accountDetails?.teams || []).map(ensureTeam);
-                recs.forEach(rec => rec.totalLBs++);
-            } catch (err) {
-                logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB', {
-                    account_id: redactAccountId(doc.account_id),
-                    error: err.message
-                });
-            }
-        }
-        logger.debug('loadbalancers: processTlsConfigurations - processed Classic ELBs', { count: classicCount });
-
-        // Process ELB v2 Listeners
-        const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
-
-        let firstListenerDoc = null;
-        for await (const doc of elbV2ListenersCursor) {
-            listenerCount++;
-            if (!firstListenerDoc) {
-                firstListenerDoc = doc;
-                logger.debug('loadbalancers: processTlsConfigurations - first listener doc sample', {
-                    account_id: redactAccountId(doc.account_id),
-                    hasConfiguration: !!doc.Configuration,
-                    hasNestedConfig: !!doc.Configuration?.configuration,
-                    protocol: doc.Configuration?.configuration?.protocol,
-                    sslPolicy: doc.Configuration?.configuration?.sslPolicy
-                });
-            }
-            try {
-                if (!doc.account_id) continue;
-
-                const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                if (!accountDetails || !accountDetails.teams || !Array.isArray(accountDetails.teams)) continue;
-
-                const recs = accountDetails.teams.map(ensureTeam);
-
-                if (doc.Configuration) {
-                    const protocol = doc.Configuration.Protocol;
-                    if (protocol === "HTTPS" || protocol === "TLS") {
-                        httpsListenerCount++;
-                        const policy = doc.Configuration.SslPolicy || "Unknown";
-                        recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
-                    }
-                }
-            } catch (err) {
-                logger.warn('loadbalancers: processTlsConfigurations - error processing listener', {
-                    account_id: redactAccountId(doc.account_id),
-                    error: err.message
-                });
-            }
-        }
-        logger.info('loadbalancers: processTlsConfigurations - processed listeners', {
-            total: listenerCount,
-            httpsOrTls: httpsListenerCount
-        });
-
-        // Process Classic ELBs
-        const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
-
-        for await (const doc of elbClassicCursor) {
-            try {
-                const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
-                if (!accountDetails?.teams) {
-                    logger.error('loadbalancers: processTlsConfigurations - missing account details or teams for Classic ELB listeners', {
-                        account_id: redactAccountId(doc.account_id),
-                        hasAccountDetails: !!accountDetails,
-                        hasTeams: !!accountDetails?.teams
-                    });
-                }
-                const recs = (accountDetails?.teams || []).map(ensureTeam);
-
-                if (doc.Configuration?.ListenerDescriptions) {
-                    for (const listenerDesc of doc.Configuration.ListenerDescriptions) {
-                        const listener = listenerDesc.Listener;
-                        if (listener?.Protocol === "HTTPS" || listener?.Protocol === "SSL") {
-                            const policy = listenerDesc.PolicyNames?.[0] || "Classic-Default";
-                            recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
-                        }
-                    }
-                }
-            } catch (err) {
-                logger.warn('loadbalancers: processTlsConfigurations - error processing Classic ELB listeners', {
-                    account_id: redactAccountId(doc.account_id),
-                    error: err.message
-                });
-            }
-        }
-
-    } catch (err) {
-        logger.error('loadbalancers: processTlsConfigurations - error in processing', { error: err.message });
+    for await (const doc of elbClassicTotalCursor) {
+        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const recs = (accountDetails?.teams || []).map(ensureTeam);
+        recs.forEach(rec => rec.totalLBs++);
     }
 
-    logger.info('loadbalancers: processTlsConfigurations - completed', {
-        teamCount: teamTls.size,
-        teams: Array.from(teamTls.keys())
-    });
+    // Process ELB v2 Listeners
+    const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
+
+    for await (const doc of elbV2ListenersCursor) {
+        if (!doc.account_id) continue;
+
+        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        if (!accountDetails || !accountDetails.teams || !Array.isArray(accountDetails.teams)) continue;
+
+        const recs = accountDetails.teams.map(ensureTeam);
+
+        if (doc.Configuration) {
+            const protocol = doc.Configuration.Protocol;
+            if (protocol === "HTTPS" || protocol === "TLS") {
+                const policy = doc.Configuration.SslPolicy || "Unknown";
+                recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
+            }
+        }
+    }
+
+    // Process Classic ELBs
+    const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
+
+    for await (const doc of elbClassicCursor) {
+        const accountDetails = accountDetailsResults.findByAccountId(doc.account_id);
+        const recs = (accountDetails?.teams || []).map(ensureTeam);
+
+        if (doc.Configuration?.ListenerDescriptions) {
+            for (const listenerDesc of doc.Configuration.ListenerDescriptions) {
+                const listener = listenerDesc.Listener;
+                if (listener?.Protocol === "HTTPS" || listener?.Protocol === "SSL") {
+                    const policy = listenerDesc.PolicyNames?.[0] || "Classic-Default";
+                    recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
+                }
+            }
+        }
+    }
 
     return teamTls;
 }
@@ -487,10 +358,7 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
 }
 
 async function processLoadBalancerTypes(req, year, month, day) {
-    logger.info('loadbalancers: processLoadBalancerTypes - starting', { year, month, day });
     const teamTypes = new Map();
-    let elbV2Count = 0;
-    let classicCount = 0;
 
     const ensureTeam = t => {
         if (!teamTypes.has(t))
@@ -502,66 +370,20 @@ async function processLoadBalancerTypes(req, year, month, day) {
 
     const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { account_id: 1, Configuration: 1 });
 
-    let firstDoc = null;
     for await (const doc of elbV2Cursor) {
-        elbV2Count++;
-        if (!firstDoc) {
-            firstDoc = doc;
-            logger.debug('loadbalancers: processLoadBalancerTypes - first ELB v2 doc sample', {
-                account_id: redactAccountId(doc.account_id),
-                hasConfiguration: !!doc.Configuration,
-                type: doc.Configuration?.Type
-            });
-        }
-        try {
-            const accountDetails = results.findByAccountId(doc.account_id);
-            if (!accountDetails?.teams) {
-                logger.error('loadbalancers: processLoadBalancerTypes - missing account details or teams', {
-                    account_id: redactAccountId(doc.account_id),
-                    hasAccountDetails: !!accountDetails,
-                    hasTeams: !!accountDetails?.teams
-                });
-            }
-            const recs = (accountDetails?.teams || []).map(ensureTeam);
-            const type = doc.Configuration?.Type || "Unknown";
-            recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
-        } catch (err) {
-            logger.warn('loadbalancers: processLoadBalancerTypes - error processing ELB v2', {
-                account_id: redactAccountId(doc.account_id),
-                error: err.message
-            });
-        }
+        const accountDetails = results.findByAccountId(doc.account_id);
+        const recs = (accountDetails?.teams || []).map(ensureTeam);
+        const type = doc.Configuration?.Type || "Unknown";
+        recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
     }
-    logger.debug('loadbalancers: processLoadBalancerTypes - processed ELB v2', { count: elbV2Count });
 
     const elbClassicCursor = await getElbClassicForDate(req, year, month, day, { account_id: 1 });
 
     for await (const doc of elbClassicCursor) {
-        classicCount++;
-        try {
-            const accountDetails = results.findByAccountId(doc.account_id);
-            if (!accountDetails?.teams) {
-                logger.error('loadbalancers: processLoadBalancerTypes - missing account details or teams for Classic ELB', {
-                    account_id: redactAccountId(doc.account_id),
-                    hasAccountDetails: !!accountDetails,
-                    hasTeams: !!accountDetails?.teams
-                });
-            }
-            const recs = (accountDetails?.teams || []).map(ensureTeam);
-            recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
-        } catch (err) {
-            logger.warn('loadbalancers: processLoadBalancerTypes - error processing Classic ELB', {
-                account_id: redactAccountId(doc.account_id),
-                error: err.message
-            });
-        }
+        const accountDetails = results.findByAccountId(doc.account_id);
+        const recs = (accountDetails?.teams || []).map(ensureTeam);
+        recs.forEach(rec => rec.types.set("classic", (rec.types.get("classic") || 0) + 1));
     }
-    logger.debug('loadbalancers: processLoadBalancerTypes - processed Classic ELBs', { count: classicCount });
-
-    logger.info('loadbalancers: processLoadBalancerTypes - completed', {
-        teamCount: teamTypes.size,
-        teams: Array.from(teamTypes.keys())
-    });
 
     return teamTypes;
 }

--- a/portal/queries/compliance/loadbalancers.js
+++ b/portal/queries/compliance/loadbalancers.js
@@ -42,7 +42,7 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
     // Get all NLBs (type="network")
     const elbV2Cursor = await getElbV2ForDate(req, year, month, day, { resource_id: 1, Configuration: 1 });
     for await (const doc of elbV2Cursor) {
-        const type = doc.Configuration?.Type;
+        const type = doc.Configuration?.configuration?.type;
         if (type === "network") {
             nlbArns.add(doc.resource_id);
         }
@@ -51,8 +51,8 @@ async function getNlbsWithOnlyTcpUdpListeners(req, year, month, day) {
     // Check which NLBs have TLS listeners
     const listenersCursor = await getElbV2ListenersForDate(req, year, month, day, { Configuration: 1 });
     for await (const doc of listenersCursor) {
-        const protocol = doc.Configuration?.Protocol;
-        const loadBalancerArn = doc.Configuration?.LoadBalancerArn;
+        const protocol = doc.Configuration?.configuration?.Protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
 
         if (loadBalancerArn && protocol === "TLS") {
             nlbsWithTlsListeners.add(loadBalancerArn);
@@ -127,9 +127,9 @@ async function processTlsConfigurations(req, year, month, day) {
         const recs = accountDetails.teams.map(ensureTeam);
 
         if (doc.Configuration) {
-            const protocol = doc.Configuration.Protocol;
+            const protocol = doc.Configuration?.configuration?.Protocol;
             if (protocol === "HTTPS" || protocol === "TLS") {
-                const policy = doc.Configuration.SslPolicy || "Unknown";
+                const policy = doc.Configuration?.configuration?.SslPolicy || "Unknown";
                 recs.forEach(rec => rec.tlsVersions.set(policy, (rec.tlsVersions.get(policy) || 0) + 1));
             }
         }
@@ -187,10 +187,10 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
         const elbV2ListenersCursor = await getElbV2ListenersForDate(req, year, month, day, { Configuration: 1 });
 
         for await (const doc of elbV2ListenersCursor) {
-            const protocol = doc.Configuration?.Protocol;
+            const protocol = doc.Configuration?.configuration?.Protocol;
 
             if (protocol === "HTTPS" || protocol === "TLS") {
-                const loadBalancerArn = doc.Configuration?.LoadBalancerArn;
+                const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
 
                 if (loadBalancerArn) {
                     tlsLoadBalancerArns.add(loadBalancerArn);
@@ -208,17 +208,17 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
             if (!hasExactMatch && !hasShortIdMatch) {
                 allResources.push({
                     resourceId: resourceId,
-                    shortName: lbDoc.Configuration?.LoadBalancerName || resourceId,
-                    type: lbDoc.Configuration?.Type || "Unknown",
-                    scheme: lbDoc.Configuration?.Scheme || "Unknown",
+                    shortName: lbDoc.Configuration?.configuration?.loadBalancerName || resourceId,
+                    type: lbDoc.Configuration?.configuration?.type || "Unknown",
+                    scheme: lbDoc.Configuration?.configuration?.scheme || "Unknown",
                     accountId: lbDoc.account_id,
                     tlsPolicy: "NO CERTS",
                     details: {
-                        dnsName: lbDoc.Configuration?.DNSName,
-                        availabilityZones: lbDoc.Configuration?.AvailabilityZones?.map(az => az.ZoneName).join(", "),
-                        securityGroups: lbDoc.Configuration?.SecurityGroups?.join(", "),
-                        vpcId: lbDoc.Configuration?.VpcId,
-                        state: lbDoc.Configuration?.State?.Code
+                        dnsName: lbDoc.Configuration?.configuration?.dNSName,
+                        availabilityZones: lbDoc.Configuration?.configuration?.availabilityZones?.map(az => az.ZoneName).join(", "),
+                        securityGroups: lbDoc.Configuration?.configuration?.securityGroups?.join(", "),
+                        vpcId: lbDoc.Configuration?.configuration?.vpcId,
+                        state: lbDoc.Configuration?.configuration?.state?.code
                     }
                 });
             }
@@ -280,10 +280,10 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
 
         for await (const doc of elbV2ListenersCursor) {
             if (doc.Configuration) {
-                const protocol = doc.Configuration.Protocol;
+                const protocol = doc.Configuration?.configuration?.Protocol;
                 if (protocol === "HTTPS" || protocol === "TLS") {
-                    const policy = doc.Configuration.SslPolicy || "Unknown";
-                    const loadBalancerArn = doc.Configuration.LoadBalancerArn;
+                    const policy = doc.Configuration?.configuration?.SslPolicy || "Unknown";
+                    const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
 
                     if (policy === tlsVersion && loadBalancerArn) {
                         let lbDoc = null;
@@ -300,17 +300,17 @@ async function getLoadBalancerDetails(req, year, month, day, team, tlsVersion) {
                         if (lbDoc) {
                             allResources.push({
                                 resourceId: loadBalancerArn,
-                                shortName: lbDoc.Configuration?.LoadBalancerName || loadBalancerArn,
-                                type: lbDoc.Configuration?.Type || "Unknown",
-                                scheme: lbDoc.Configuration?.Scheme || "Unknown",
+                                shortName: lbDoc.Configuration?.configuration?.loadBalancerName || loadBalancerArn,
+                                type: lbDoc.Configuration?.configuration?.type || "Unknown",
+                                scheme: lbDoc.Configuration?.configuration?.scheme || "Unknown",
                                 accountId: doc.account_id,
                                 tlsPolicy: policy,
                                 details: {
-                                    dnsName: lbDoc.Configuration?.DNSName,
-                                    availabilityZones: lbDoc.Configuration?.AvailabilityZones?.map(az => az.ZoneName).join(", "),
-                                    securityGroups: lbDoc.Configuration?.SecurityGroups?.join(", "),
-                                    vpcId: lbDoc.Configuration?.VpcId,
-                                    state: lbDoc.Configuration?.State?.Code
+                                    dnsName: lbDoc.Configuration?.configuration?.dNSName,
+                                    availabilityZones: lbDoc.Configuration?.configuration?.availabilityZones?.map(az => az.ZoneName).join(", "),
+                                    securityGroups: lbDoc.Configuration?.configuration?.securityGroups?.join(", "),
+                                    vpcId: lbDoc.Configuration?.configuration?.vpcId,
+                                    state: lbDoc.Configuration?.configuration?.state?.code
                                 }
                             });
                         }
@@ -373,7 +373,7 @@ async function processLoadBalancerTypes(req, year, month, day) {
     for await (const doc of elbV2Cursor) {
         const accountDetails = await results.findByAccountId(doc.account_id);
         const recs = (accountDetails?.teams || []).map(ensureTeam);
-        const type = doc.Configuration?.Type || "Unknown";
+        const type = doc.Configuration?.configuration?.type || "Unknown";
         recs.forEach(rec => rec.types.set(type, (rec.types.get(type) || 0) + 1));
     }
 
@@ -420,26 +420,26 @@ async function getLoadBalancerTypeDetails(req, year, month, day, team, type) {
         for await (const doc of elbV2Cursor) {
             if (!(await results.findByAccountId(doc.account_id))?.teams?.find(t => t === team)) continue;
 
-            const docType = doc.Configuration?.Type;
+            const docType = doc.Configuration?.configuration?.type;
             if (docType === type) {
                 allResources.push({
                     resourceId: doc.resource_id,
-                    shortName: doc.Configuration?.LoadBalancerName || doc.resource_id,
+                    shortName: doc.Configuration?.configuration?.loadBalancerName || doc.resource_id,
                     type: (() => {
                         if (docType === "application") return "ALB";
                         if (docType === "network") return "NLB";
                         if (docType === "classic") return "Classic";
                         return docType;
                     })(),
-                    scheme: doc.Configuration?.Scheme || "Unknown",
+                    scheme: doc.Configuration?.configuration?.scheme || "Unknown",
                     accountId: doc.account_id,
                     details: {
-                        dnsName: doc.Configuration?.DNSName,
-                        availabilityZones: doc.Configuration?.AvailabilityZones?.map(az => az.ZoneName).join(", "),
-                        securityGroups: doc.Configuration?.SecurityGroups?.join(", "),
-                        vpcId: doc.Configuration?.VpcId,
-                        state: doc.Configuration?.State?.Code,
-                        createdTime: doc.Configuration?.CreatedTime
+                        dnsName: doc.Configuration?.configuration?.dNSName,
+                        availabilityZones: doc.Configuration?.configuration?.availabilityZones?.map(az => az.zoneName).join(", "),
+                        securityGroups: doc.Configuration?.configuration?.securityGroups?.join(", "),
+                        vpcId: doc.Configuration?.configuration?.vpcId,
+                        state: doc.Configuration?.configuration?.state?.code,
+                        createdTime: doc.Configuration?.configuration?.createdTime
                     }
                 });
             }

--- a/portal/queries/compliance/overview.js
+++ b/portal/queries/compliance/overview.js
@@ -189,8 +189,10 @@ async function getLoadBalancerNonCompliant(req, year, month, day) {
     const secureLoadBalancers = new Set();
 
     for await (const doc of listenersCursor) {
-        if (doc.Protocol === 'HTTPS' || doc.Protocol === 'TLS') {
-            secureLoadBalancers.add(doc.LoadBalancerArn);
+        const protocol = doc.Configuration?.configuration?.protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
+        if (protocol === 'HTTPS' || protocol === 'TLS') {
+            secureLoadBalancers.add(loadBalancerArn);
         }
     }
 
@@ -199,7 +201,7 @@ async function getLoadBalancerNonCompliant(req, year, month, day) {
     const elbV2Cursor = elbV2Collection.find({ year, month, day });
 
     for await (const doc of elbV2Cursor) {
-        if (!secureLoadBalancers.has(doc.LoadBalancerArn)) {
+        if (!secureLoadBalancers.has(doc.resource_id)) {
             const accountDetails = results.findByAccountId(doc.account_id);
             accountDetails.teams.forEach(team => { if (team) teamsWithIssues.add(team); });
             accountDetails.tenants.forEach(tenant => {

--- a/portal/queries/compliance/overview.js
+++ b/portal/queries/compliance/overview.js
@@ -83,7 +83,7 @@ async function getTaggingNonCompliant(req, year, month, day) {
     for await (const doc of cursor) {
         if (doc.resource_type === "bucket" && bucketStartsWithAccountId(doc.resource_id)) continue;
 
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
         const tenants = accountDetails.tenants || [];
 
@@ -160,7 +160,7 @@ async function getDatabaseNonCompliant(req, year, month, day) {
         }
 
         if (isDeprecated) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             accountDetails.teams.forEach(team => { if (team) teamsWithIssues.add(team); });
             accountDetails.tenants.forEach(tenant => {
                 const tenantId = tenant.Id || tenant.id;
@@ -202,7 +202,7 @@ async function getLoadBalancerNonCompliant(req, year, month, day) {
 
     for await (const doc of elbV2Cursor) {
         if (!secureLoadBalancers.has(doc.resource_id)) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             accountDetails.teams.forEach(team => { if (team) teamsWithIssues.add(team); });
             accountDetails.tenants.forEach(tenant => {
                 const tenantId = tenant.Id || tenant.id;
@@ -224,7 +224,7 @@ async function getLoadBalancerNonCompliant(req, year, month, day) {
         }
 
         if (!hasHttps) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             accountDetails.teams.forEach(team => { if (team) teamsWithIssues.add(team); });
             accountDetails.tenants.forEach(tenant => {
                 const tenantId = tenant.Id || tenant.id;
@@ -251,7 +251,7 @@ async function getKmsNonCompliant(req, year, month, day) {
 
     for await (const doc of cursor) {
         if (doc.KeyRotationEnabled !== true) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             accountDetails.teams.forEach(team => { if (team) teamsWithIssues.add(team); });
             accountDetails.tenants.forEach(tenant => {
                 const tenantId = tenant.Id || tenant.id;
@@ -279,7 +279,7 @@ async function getAutoScalingNonCompliant(req, year, month, day) {
     for await (const doc of cursor) {
         const instances = doc.Configuration?.Instances || [];
         if (instances.length === 0) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             accountDetails.teams.forEach(team => { if (team) teamsWithIssues.add(team); });
             accountDetails.tenants.forEach(tenant => {
                 const tenantId = tenant.Id || tenant.id;

--- a/portal/queries/compliance/tagging.js
+++ b/portal/queries/compliance/tagging.js
@@ -57,7 +57,7 @@ async function processTeamsTagCompliance(req, cursor) {
     for await (const doc of cursor) {
         if (doc.resource_type === "bucket" && bucketStartsWithAccountId(doc.resource_id)) continue;
 
-	const recs = results.findByAccountId(doc.account_id).teams.map(ensureTeam);
+	const recs = (await results.findByAccountId(doc.account_id)).teams.map(ensureTeam);
 
         const resourceType = doc.resource_type || "Unknown";
 

--- a/portal/queries/compliance/teams.js
+++ b/portal/queries/compliance/teams.js
@@ -216,15 +216,17 @@ async function aggregateLoadBalancersByTeam(req, year, month, day) {
     const secureLoadBalancers = new Set();
 
     for await (const doc of listenersCursor) {
-        if (doc.Protocol === 'HTTPS' || doc.Protocol === 'TLS') {
-            secureLoadBalancers.add(doc.LoadBalancerArn);
+        const protocol = doc.Configuration?.configuration?.protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
+        if (protocol === 'HTTPS' || protocol === 'TLS') {
+            secureLoadBalancers.add(loadBalancerArn);
         }
     }
 
     // Count secure load balancers per team
     const elbV2Cursor2 = elbV2Collection.find({ year, month, day });
     for await (const doc of elbV2Cursor2) {
-        if (secureLoadBalancers.has(doc.LoadBalancerArn)) {
+        if (secureLoadBalancers.has(doc.resource_id)) {
             const accountDetails = results.findByAccountId(doc.account_id);
             const teams = accountDetails.teams || [];
 

--- a/portal/queries/compliance/teams.js
+++ b/portal/queries/compliance/teams.js
@@ -204,7 +204,7 @@ async function aggregateLoadBalancersByTeam(req, year, month, day) {
             const stats = teamStats.get(team);
             stats.totalLoadBalancers++;
 
-            const lbType = doc.Type || 'unknown';
+            const lbType = doc.Configuration?.configuration?.type || 'unknown';
             if (lbType === 'application') stats.albCount++;
             else if (lbType === 'network') stats.nlbCount++;
         }
@@ -216,8 +216,8 @@ async function aggregateLoadBalancersByTeam(req, year, month, day) {
     const secureLoadBalancers = new Set();
 
     for await (const doc of listenersCursor) {
-        const protocol = doc.Configuration?.configuration?.protocol;
-        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
+        const protocol = doc.Configuration?.configuration?.Protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
         if (protocol === 'HTTPS' || protocol === 'TLS') {
             secureLoadBalancers.add(loadBalancerArn);
         }

--- a/portal/queries/compliance/teams.js
+++ b/portal/queries/compliance/teams.js
@@ -28,7 +28,7 @@ async function aggregateTaggingByTeam(req, year, month, day) {
     for await (const doc of cursor) {
         if (doc.resource_type === "bucket" && bucketStartsWithAccountId(doc.resource_id)) continue;
 
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         if (teams.length === 0) continue;
@@ -114,7 +114,7 @@ async function aggregateDatabaseByTeam(req, year, month, day) {
     const rdsCursor = rdsCollection.find({ year, month, day });
 
     for await (const doc of rdsCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         for (const team of teams) {
@@ -150,7 +150,7 @@ async function aggregateDatabaseByTeam(req, year, month, day) {
     const redshiftCursor = redshiftCollection.find({ year, month, day });
 
     for await (const doc of redshiftCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         for (const team of teams) {
@@ -184,7 +184,7 @@ async function aggregateLoadBalancersByTeam(req, year, month, day) {
     const elbV2Cursor = elbV2Collection.find({ year, month, day });
 
     for await (const doc of elbV2Cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         for (const team of teams) {
@@ -227,7 +227,7 @@ async function aggregateLoadBalancersByTeam(req, year, month, day) {
     const elbV2Cursor2 = elbV2Collection.find({ year, month, day });
     for await (const doc of elbV2Cursor2) {
         if (secureLoadBalancers.has(doc.resource_id)) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             const teams = accountDetails.teams || [];
 
             for (const team of teams) {
@@ -243,7 +243,7 @@ async function aggregateLoadBalancersByTeam(req, year, month, day) {
     const classicCursor = classicCollection.find({ year, month, day });
 
     for await (const doc of classicCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         for (const team of teams) {
@@ -287,7 +287,7 @@ async function aggregateKmsByTeam(req, year, month, day) {
     const cursor = collection.find({ year, month, day });
 
     for await (const doc of cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         for (const team of teams) {
@@ -323,7 +323,7 @@ async function aggregateAutoScalingByTeam(req, year, month, day) {
     const cursor = collection.find({ year, month, day });
 
     for await (const doc of cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const teams = accountDetails.teams || [];
 
         for (const team of teams) {

--- a/portal/queries/compliance/tenants.js
+++ b/portal/queries/compliance/tenants.js
@@ -225,15 +225,17 @@ async function aggregateLoadBalancersByTenant(req, year, month, day) {
     const secureLoadBalancers = new Set();
 
     for await (const doc of listenersCursor) {
-        if (doc.Protocol === 'HTTPS' || doc.Protocol === 'TLS') {
-            secureLoadBalancers.add(doc.LoadBalancerArn);
+        const protocol = doc.Configuration?.configuration?.protocol;
+        const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
+        if (protocol === 'HTTPS' || protocol === 'TLS') {
+            secureLoadBalancers.add(loadBalancerArn);
         }
     }
 
     // Count secure load balancers per tenant
     const elbV2Cursor2 = elbV2Collection.find({ year, month, day });
     for await (const doc of elbV2Cursor2) {
-        if (secureLoadBalancers.has(doc.LoadBalancerArn)) {
+        if (secureLoadBalancers.has(doc.resource_id)) {
             const accountDetails = results.findByAccountId(doc.account_id);
             const tenants = accountDetails.tenants || [];
 

--- a/portal/queries/compliance/tenants.js
+++ b/portal/queries/compliance/tenants.js
@@ -28,7 +28,7 @@ async function aggregateTaggingByTenant(req, year, month, day) {
     for await (const doc of cursor) {
         if (doc.resource_type === "bucket" && bucketStartsWithAccountId(doc.resource_id)) continue;
 
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         if (tenants.length === 0) continue;
@@ -117,7 +117,7 @@ async function aggregateDatabaseByTenant(req, year, month, day) {
     const rdsCursor = rdsCollection.find({ year, month, day });
 
     for await (const doc of rdsCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         for (const tenant of tenants) {
@@ -155,7 +155,7 @@ async function aggregateDatabaseByTenant(req, year, month, day) {
     const redshiftCursor = redshiftCollection.find({ year, month, day });
 
     for await (const doc of redshiftCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         for (const tenant of tenants) {
@@ -191,7 +191,7 @@ async function aggregateLoadBalancersByTenant(req, year, month, day) {
     const elbV2Cursor = elbV2Collection.find({ year, month, day });
 
     for await (const doc of elbV2Cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         for (const tenant of tenants) {
@@ -236,7 +236,7 @@ async function aggregateLoadBalancersByTenant(req, year, month, day) {
     const elbV2Cursor2 = elbV2Collection.find({ year, month, day });
     for await (const doc of elbV2Cursor2) {
         if (secureLoadBalancers.has(doc.resource_id)) {
-            const accountDetails = results.findByAccountId(doc.account_id);
+            const accountDetails = await results.findByAccountId(doc.account_id);
             const tenants = accountDetails.tenants || [];
 
             for (const tenant of tenants) {
@@ -253,7 +253,7 @@ async function aggregateLoadBalancersByTenant(req, year, month, day) {
     const classicCursor = classicCollection.find({ year, month, day });
 
     for await (const doc of classicCursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         for (const tenant of tenants) {
@@ -299,7 +299,7 @@ async function aggregateKmsByTenant(req, year, month, day) {
     const cursor = collection.find({ year, month, day });
 
     for await (const doc of cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         for (const tenant of tenants) {
@@ -337,7 +337,7 @@ async function aggregateAutoScalingByTenant(req, year, month, day) {
     const cursor = collection.find({ year, month, day });
 
     for await (const doc of cursor) {
-        const accountDetails = results.findByAccountId(doc.account_id);
+        const accountDetails = await results.findByAccountId(doc.account_id);
         const tenants = accountDetails.tenants || [];
 
         for (const tenant of tenants) {

--- a/portal/queries/compliance/tests/loadbalancers.test.js
+++ b/portal/queries/compliance/tests/loadbalancers.test.js
@@ -88,8 +88,8 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
                 {
                     Configuration: {
                         configuration: {
-                            Protocol: 'TCP',
-                            LoadBalancerArn: nlbArn
+                            protocol: 'TCP',
+                            loadBalancerArn: nlbArn
                         }
                     }
                 }
@@ -116,8 +116,8 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
                 {
                     Configuration: {
                         configuration: {
-                            Protocol: 'UDP',
-                            LoadBalancerArn: nlbArn
+                            protocol: 'UDP',
+                            loadBalancerArn: nlbArn
                         }
                     }
                 }
@@ -144,8 +144,8 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
                 {
                     Configuration: {
                         configuration: {
-                            Protocol: 'TCP_UDP',
-                            LoadBalancerArn: nlbArn
+                            protocol: 'TCP_UDP',
+                            loadBalancerArn: nlbArn
                         }
                     }
                 }
@@ -172,9 +172,9 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
                 {
                     Configuration: {
                         configuration: {
-                            Protocol: 'TLS',
-                            LoadBalancerArn: nlbArn,
-                            SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06'
+                            protocol: 'TLS',
+                            loadBalancerArn: nlbArn,
+                            sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06'
                         }
                     }
                 }
@@ -200,17 +200,17 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
                 {
                     Configuration: {
                         configuration: {
-                            Protocol: 'TCP',
-                            LoadBalancerArn: nlbArn
+                            protocol: 'TCP',
+                            loadBalancerArn: nlbArn
                         }
                     }
                 },
                 {
                     Configuration: {
                         configuration: {
-                            Protocol: 'TLS',
-                            LoadBalancerArn: nlbArn,
-                            SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06'
+                            protocol: 'TLS',
+                            loadBalancerArn: nlbArn,
+                            sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06'
                         }
                     }
                 }
@@ -235,12 +235,12 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
             ],
             elb_v2_listeners: [
                 // TCP-only NLB
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpOnlyNlb } } },
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpOnlyNlb } } },
                 // TLS NLB
-                { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: tlsNlb, SslPolicy: 'policy' } } },
+                { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: tlsNlb, sslPolicy: 'policy' } } },
                 // Mixed NLB (TCP + TLS)
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: mixedNlb } } },
-                { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: mixedNlb, SslPolicy: 'policy' } } }
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: mixedNlb } } },
+                { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: mixedNlb, sslPolicy: 'policy' } } }
             ]
         });
 
@@ -282,7 +282,7 @@ describe('getNlbsWithOnlyTcpUdpListeners', () => {
             ],
             elb_v2_listeners: [
                 // Listener ARN has different account ID but same short ID
-                { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: nlbArn2, SslPolicy: 'policy' } } }
+                { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: nlbArn2, sslPolicy: 'policy' } } }
             ]
         });
 
@@ -309,9 +309,9 @@ describe('processTlsConfigurations - TCP/UDP NLB Exclusion', () => {
             ],
             elb_v2_listeners: [
                 // ALB with HTTPS
-                { account_id: '123456789012', Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: albArn, SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } },
+                { account_id: '123456789012', Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: albArn, sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } },
                 // NLB with TCP only
-                { account_id: '123456789012', Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } }
+                { account_id: '123456789012', Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } }
             ],
             elb_classic: []
         });
@@ -331,7 +331,7 @@ describe('processTlsConfigurations - TCP/UDP NLB Exclusion', () => {
                 { resource_id: tlsNlbArn, account_id: '123456789012', Configuration: { configuration: { type: 'network' } } }
             ],
             elb_v2_listeners: [
-                { account_id: '123456789012', Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: tlsNlbArn, SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } }
+                { account_id: '123456789012', Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: tlsNlbArn, sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } }
             ],
             elb_classic: []
         });
@@ -381,7 +381,7 @@ describe('getLoadBalancerDetails - NO CERTS exclusion', () => {
                 }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } }
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } }
             ],
             elb_classic: []
         });
@@ -410,7 +410,7 @@ describe('getLoadBalancerDetails - NO CERTS exclusion', () => {
                 }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'HTTP', LoadBalancerArn: httpAlbArn } } }
+                { Configuration: { configuration: { protocol: 'HTTP', loadBalancerArn: httpAlbArn } } }
             ],
             elb_classic: []
         });
@@ -473,7 +473,7 @@ describe('getLoadBalancerDetails - NO CERTS exclusion', () => {
                 }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: httpsAlbArn, SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } }
+                { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: httpsAlbArn, sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } }
             ],
             elb_classic: []
         });
@@ -498,10 +498,10 @@ describe('getLoadBalancerDetails - NO CERTS exclusion', () => {
                 { resource_id: tlsNlbArn, account_id: '123456789012', Configuration: { configuration: { type: 'network', loadBalancerName: 'tls-nlb' } } }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'HTTP', LoadBalancerArn: httpAlbArn } } },
-                { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: httpsAlbArn, SslPolicy: 'policy' } } },
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } },
-                { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: tlsNlbArn, SslPolicy: 'policy' } } }
+                { Configuration: { configuration: { protocol: 'HTTP', loadBalancerArn: httpAlbArn } } },
+                { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: httpsAlbArn, sslPolicy: 'policy' } } },
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } },
+                { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: tlsNlbArn, sslPolicy: 'policy' } } }
             ],
             elb_classic: []
         });
@@ -530,9 +530,9 @@ describe('Protocol handling edge cases', () => {
                 { resource_id: nlbArn, Configuration: { configuration: { type: 'network' } } }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: nlbArn, Port: 80 } } },
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: nlbArn, Port: 443 } } },
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: nlbArn, Port: 8080 } } }
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: nlbArn, Port: 80 } } },
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: nlbArn, Port: 443 } } },
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: nlbArn, Port: 8080 } } }
             ]
         });
 
@@ -552,7 +552,7 @@ describe('Protocol handling edge cases', () => {
             elb_v2_listeners: [
                 { Configuration: null },
                 { Configuration: { configuration: null } },
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: nlbArn } } }
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: nlbArn } } }
             ]
         });
 
@@ -570,7 +570,7 @@ describe('Protocol handling edge cases', () => {
                 { resource_id: albArn, Configuration: { configuration: { type: 'application' } } }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'HTTP', LoadBalancerArn: albArn } } }
+                { Configuration: { configuration: { protocol: 'HTTP', loadBalancerArn: albArn } } }
             ]
         });
 

--- a/portal/queries/dashboard/active-albs.js
+++ b/portal/queries/dashboard/active-albs.js
@@ -27,12 +27,12 @@ class ActiveAlbsMetric extends DashboardMetric {
 
         for await (const doc of elbV2Cursor) {
             // Only count Application Load Balancers
-            const type = doc.Configuration?.Type;
+            const type = doc.Configuration?.configuration?.type;
             if (type === 'application') {
                 totalALBs++;
 
                 // Check if ALB is active (provisioning or active state)
-                const state = doc.Configuration?.State?.Code;
+                const state = doc.Configuration?.configuration?.state?.code;
                 if (state === 'active' || state === 'provisioning') {
                     activeALBs++;
                 }
@@ -97,11 +97,11 @@ class ActiveAlbsMetric extends DashboardMetric {
         let activeALBs = 0;
         
         for await (const doc of elbV2Cursor) {
-            const type = doc.Configuration?.Type;
+            const type = doc.Configuration?.configuration?.type;
             if (type === 'application') {
                 totalALBs++;
                 
-                const state = doc.Configuration?.State?.Code;
+                const state = doc.Configuration?.configuration?.state?.code;
                 if (state === 'active' || state === 'provisioning') {
                     activeALBs++;
                 }

--- a/portal/queries/dashboard/configured-albs.js
+++ b/portal/queries/dashboard/configured-albs.js
@@ -45,7 +45,7 @@ class ConfiguredAlbsMetric extends DashboardMetric {
         }
         
         for await (const doc of elbV2Cursor) {
-            const type = doc.Configuration?.Type;
+            const type = doc.Configuration?.configuration?.type;
             if (type === 'application') {
                 totalALBs++;
                 
@@ -122,7 +122,7 @@ class ConfiguredAlbsMetric extends DashboardMetric {
         }
         
         for await (const doc of elbV2Cursor) {
-            const type = doc.Configuration?.Type;
+            const type = doc.Configuration?.configuration?.type;
             if (type === 'application') {
                 totalALBs++;
                 

--- a/portal/queries/dashboard/secure-loadbalancers.js
+++ b/portal/queries/dashboard/secure-loadbalancers.js
@@ -47,8 +47,8 @@ class SecureLoadBalancersMetric extends DashboardMetric {
         });
 
         for await (const doc of listenersCursor) {
-            const protocol = doc.Configuration?.configuration?.Protocol;
-            const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
+            const protocol = doc.Configuration?.configuration?.protocol;
+            const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
 
             if (loadBalancerArn && protocol === "TLS") {
                 nlbsWithTlsListeners.add(loadBalancerArn);
@@ -108,8 +108,8 @@ class SecureLoadBalancersMetric extends DashboardMetric {
 
         const secureElbV2 = new Set();
         for await (const doc of listenersCursor) {
-            const protocol = doc.Configuration?.configuration?.Protocol;
-            const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
+            const protocol = doc.Configuration?.configuration?.protocol;
+            const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
             if (protocol === "HTTPS" || protocol === "TLS") {
                 if (loadBalancerArn) {
                     secureElbV2.add(loadBalancerArn);
@@ -212,8 +212,8 @@ class SecureLoadBalancersMetric extends DashboardMetric {
 
         const secureElbV2 = new Set();
         for await (const doc of listenersCursor) {
-            const protocol = doc.Configuration?.configuration?.Protocol;
-            const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
+            const protocol = doc.Configuration?.configuration?.protocol;
+            const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
             if (protocol === "HTTPS" || protocol === "TLS") {
                 if (loadBalancerArn) {
                     secureElbV2.add(loadBalancerArn);
@@ -290,9 +290,9 @@ class SecureLoadBalancersMetric extends DashboardMetric {
 
         const deprecatedTlsArns = new Set();
         for await (const doc of listenersCursor) {
-            const protocol = doc.Configuration?.configuration?.Protocol;
-            const sslPolicy = doc.Configuration?.configuration?.SslPolicy || '';
-            const loadBalancerArn = doc.Configuration?.configuration?.LoadBalancerArn;
+            const protocol = doc.Configuration?.configuration?.protocol;
+            const sslPolicy = doc.Configuration?.configuration?.sslPolicy || '';
+            const loadBalancerArn = doc.Configuration?.configuration?.loadBalancerArn;
 
             // Check for deprecated SSL policies (TLS < 1.2)
             if ((protocol === "HTTPS" || protocol === "TLS") &&

--- a/portal/queries/dashboard/tests/secure-loadbalancers.test.js
+++ b/portal/queries/dashboard/tests/secure-loadbalancers.test.js
@@ -70,7 +70,7 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: nlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: nlbArn } } }
+                    { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: nlbArn } } }
                 ]
             });
 
@@ -88,7 +88,7 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: nlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: nlbArn } } }
+                    { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: nlbArn } } }
                 ]
             });
 
@@ -119,7 +119,7 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: albArn, Configuration: { configuration: { type: 'application' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: albArn } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: albArn } } }
                 ],
                 elb_classic: []
             });
@@ -139,8 +139,8 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: tcpNlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: albArn } } },
-                    { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: albArn } } },
+                    { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } }
                 ],
                 elb_classic: []
             });
@@ -159,7 +159,7 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: tlsNlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: tlsNlbArn } } }
+                    { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: tlsNlbArn } } }
                 ],
                 elb_classic: []
             });
@@ -181,9 +181,9 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: tcpNlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: httpsAlbArn } } },
-                    { Configuration: { configuration: { Protocol: 'HTTP', LoadBalancerArn: httpAlbArn } } },
-                    { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: httpsAlbArn } } },
+                    { Configuration: { configuration: { protocol: 'HTTP', loadBalancerArn: httpAlbArn } } },
+                    { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } }
                 ],
                 elb_classic: []
             });
@@ -228,8 +228,8 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: tcpNlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: albArn } } },
-                    { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: albArn } } },
+                    { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } }
                 ],
                 elb_classic: []
             });
@@ -255,9 +255,9 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: tlsNlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: httpsAlbArn } } },
-                    { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } },
-                    { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: tlsNlbArn } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: httpsAlbArn } } },
+                    { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } },
+                    { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: tlsNlbArn } } }
                 ],
                 elb_classic: []
             });
@@ -285,8 +285,8 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: tcpNlbArn, Configuration: { configuration: { type: 'network' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: albArn, SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } },
-                    { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: albArn, sslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' } } },
+                    { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } }
                 ],
                 elb_classic: []
             });
@@ -318,7 +318,7 @@ describe('SecureLoadBalancersMetric', () => {
                     { resource_id: albArn, Configuration: { configuration: { type: 'application' } } }
                 ],
                 elb_v2_listeners: [
-                    { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: albArn, SslPolicy: 'ELBSecurityPolicy-TLSv1' } } }
+                    { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: albArn, sslPolicy: 'ELBSecurityPolicy-TLSv1' } } }
                 ],
                 elb_classic: []
             });
@@ -356,11 +356,11 @@ describe('Integration scenarios', () => {
                 { resource_id: udpNlbArn, Configuration: { configuration: { type: 'network' } } }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'HTTPS', LoadBalancerArn: httpsAlbArn } } },
-                { Configuration: { configuration: { Protocol: 'HTTP', LoadBalancerArn: httpAlbArn } } },
-                { Configuration: { configuration: { Protocol: 'TCP', LoadBalancerArn: tcpNlbArn } } },
-                { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: tlsNlbArn } } },
-                { Configuration: { configuration: { Protocol: 'UDP', LoadBalancerArn: udpNlbArn } } }
+                { Configuration: { configuration: { protocol: 'HTTPS', loadBalancerArn: httpsAlbArn } } },
+                { Configuration: { configuration: { protocol: 'HTTP', loadBalancerArn: httpAlbArn } } },
+                { Configuration: { configuration: { protocol: 'TCP', loadBalancerArn: tcpNlbArn } } },
+                { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: tlsNlbArn } } },
+                { Configuration: { configuration: { protocol: 'UDP', loadBalancerArn: udpNlbArn } } }
             ],
             elb_classic: [
                 {
@@ -394,7 +394,7 @@ describe('Integration scenarios', () => {
                 { resource_id: nlbArn1, Configuration: { configuration: { type: 'network' } } }
             ],
             elb_v2_listeners: [
-                { Configuration: { configuration: { Protocol: 'TLS', LoadBalancerArn: listenerLbArn } } }
+                { Configuration: { configuration: { protocol: 'TLS', loadBalancerArn: listenerLbArn } } }
             ],
             elb_classic: []
         });

--- a/portal/routes/compliance/loadbalancers.js
+++ b/portal/routes/compliance/loadbalancers.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 
+const logger = require('../../libs/logger');
 const { complianceBreadcrumbs } = require('../../utils/shared');
 const lbQueries = require('../../queries/compliance/loadbalancers');
 
@@ -9,16 +10,24 @@ router.get('/', (_, res) => {
 });
 
 router.get('/tls', async (req, res) => {
+    logger.info('loadbalancers route: GET /tls - request received');
     try {
         const latestDoc = await lbQueries.getLatestElbDate(req);
+        logger.debug('loadbalancers route: /tls - latestDoc', { latestDoc });
 
         if (!latestDoc) {
+            logger.warn('loadbalancers route: /tls - no data found in elb_v2 collection');
             throw new Error("No data found in elb_v2 collection");
         }
 
         const { year: latestYear, month: latestMonth, day: latestDay } = latestDoc;
+        logger.info('loadbalancers route: /tls - processing TLS configurations', { year: latestYear, month: latestMonth, day: latestDay });
 
         const teamTls = await lbQueries.processTlsConfigurations(req, latestYear, latestMonth, latestDay);
+        logger.debug('loadbalancers route: /tls - teamTls result', {
+            teamCount: teamTls.size,
+            teams: Array.from(teamTls.keys())
+        });
 
         const isDeprecatedPolicy = (version) => {
             return version.startsWith('ELBSecurityPolicy-2015') ||
@@ -54,6 +63,11 @@ router.get('/tls', async (req, res) => {
             };
         }).filter(t => t.totalLBs > 0);
 
+        logger.info('loadbalancers route: /tls - rendering with data', {
+            dataCount: data.length,
+            teams: data.map(d => d.team)
+        });
+
         res.render('policies/loadbalancers/tls.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer TLS Configurations",
@@ -66,6 +80,7 @@ router.get('/tls', async (req, res) => {
             currentPath: "/compliance/loadbalancers/tls"
         });
     } catch (err) {
+        logger.error('loadbalancers route: /tls - error', { error: err.message, stack: err.stack });
         res.render('errors/no-data.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer TLS Configurations",
@@ -143,16 +158,24 @@ router.get('/details', async (req, res) => {
 });
 
 router.get('/types', async (req, res) => {
+    logger.info('loadbalancers route: GET /types - request received');
     try {
         const latestDoc = await lbQueries.getLatestElbDate(req);
+        logger.debug('loadbalancers route: /types - latestDoc', { latestDoc });
 
         if (!latestDoc) {
+            logger.warn('loadbalancers route: /types - no data found in elb_v2 collection');
             throw new Error("No data found in elb_v2 collection");
         }
 
         const { year: latestYear, month: latestMonth, day: latestDay } = latestDoc;
+        logger.info('loadbalancers route: /types - processing load balancer types', { year: latestYear, month: latestMonth, day: latestDay });
 
         const teamTypes = await lbQueries.processLoadBalancerTypes(req, latestYear, latestMonth, latestDay);
+        logger.debug('loadbalancers route: /types - teamTypes result', {
+            teamCount: teamTypes.size,
+            teams: Array.from(teamTypes.keys())
+        });
 
         const data = [...teamTypes.entries()].map(([team, rec]) => ({
             team,
@@ -167,6 +190,11 @@ router.get('/types', async (req, res) => {
             }))
         })).filter(t => t.types.length > 0);
 
+        logger.info('loadbalancers route: /types - rendering with data', {
+            dataCount: data.length,
+            teams: data.map(d => d.team)
+        });
+
         res.render('policies/loadbalancers/types.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer Types by Team",
@@ -179,6 +207,7 @@ router.get('/types', async (req, res) => {
             currentPath: "/compliance/loadbalancers/types"
         });
     } catch (err) {
+        logger.error('loadbalancers route: /types - error', { error: err.message, stack: err.stack });
         res.render('errors/no-data.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer Types by Team",

--- a/portal/routes/compliance/loadbalancers.js
+++ b/portal/routes/compliance/loadbalancers.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
 
-const logger = require('../../libs/logger');
 const { complianceBreadcrumbs } = require('../../utils/shared');
 const lbQueries = require('../../queries/compliance/loadbalancers');
 
@@ -10,24 +9,16 @@ router.get('/', (_, res) => {
 });
 
 router.get('/tls', async (req, res) => {
-    logger.info('loadbalancers route: GET /tls - request received');
     try {
         const latestDoc = await lbQueries.getLatestElbDate(req);
-        logger.debug('loadbalancers route: /tls - latestDoc', { latestDoc });
 
         if (!latestDoc) {
-            logger.warn('loadbalancers route: /tls - no data found in elb_v2 collection');
             throw new Error("No data found in elb_v2 collection");
         }
 
         const { year: latestYear, month: latestMonth, day: latestDay } = latestDoc;
-        logger.info('loadbalancers route: /tls - processing TLS configurations', { year: latestYear, month: latestMonth, day: latestDay });
 
         const teamTls = await lbQueries.processTlsConfigurations(req, latestYear, latestMonth, latestDay);
-        logger.debug('loadbalancers route: /tls - teamTls result', {
-            teamCount: teamTls.size,
-            teams: Array.from(teamTls.keys())
-        });
 
         const isDeprecatedPolicy = (version) => {
             return version.startsWith('ELBSecurityPolicy-2015') ||
@@ -63,11 +54,6 @@ router.get('/tls', async (req, res) => {
             };
         }).filter(t => t.totalLBs > 0);
 
-        logger.info('loadbalancers route: /tls - rendering with data', {
-            dataCount: data.length,
-            teams: data.map(d => d.team)
-        });
-
         res.render('policies/loadbalancers/tls.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer TLS Configurations",
@@ -80,7 +66,6 @@ router.get('/tls', async (req, res) => {
             currentPath: "/compliance/loadbalancers/tls"
         });
     } catch (err) {
-        logger.error('loadbalancers route: /tls - error', { error: err.message, stack: err.stack });
         res.render('errors/no-data.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer TLS Configurations",
@@ -158,24 +143,16 @@ router.get('/details', async (req, res) => {
 });
 
 router.get('/types', async (req, res) => {
-    logger.info('loadbalancers route: GET /types - request received');
     try {
         const latestDoc = await lbQueries.getLatestElbDate(req);
-        logger.debug('loadbalancers route: /types - latestDoc', { latestDoc });
 
         if (!latestDoc) {
-            logger.warn('loadbalancers route: /types - no data found in elb_v2 collection');
             throw new Error("No data found in elb_v2 collection");
         }
 
         const { year: latestYear, month: latestMonth, day: latestDay } = latestDoc;
-        logger.info('loadbalancers route: /types - processing load balancer types', { year: latestYear, month: latestMonth, day: latestDay });
 
         const teamTypes = await lbQueries.processLoadBalancerTypes(req, latestYear, latestMonth, latestDay);
-        logger.debug('loadbalancers route: /types - teamTypes result', {
-            teamCount: teamTypes.size,
-            teams: Array.from(teamTypes.keys())
-        });
 
         const data = [...teamTypes.entries()].map(([team, rec]) => ({
             team,
@@ -190,11 +167,6 @@ router.get('/types', async (req, res) => {
             }))
         })).filter(t => t.types.length > 0);
 
-        logger.info('loadbalancers route: /types - rendering with data', {
-            dataCount: data.length,
-            teams: data.map(d => d.team)
-        });
-
         res.render('policies/loadbalancers/types.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer Types by Team",
@@ -207,7 +179,6 @@ router.get('/types', async (req, res) => {
             currentPath: "/compliance/loadbalancers/types"
         });
     } catch (err) {
-        logger.error('loadbalancers route: /types - error', { error: err.message, stack: err.stack });
         res.render('errors/no-data.njk', {
             breadcrumbs: [...complianceBreadcrumbs, { text: "Load Balancers", href: "/compliance/loadbalancers" }],
             policy_title: "Load Balancer Types by Team",

--- a/portal/routes/monitoring.js
+++ b/portal/routes/monitoring.js
@@ -1,12 +1,54 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const config = require('../libs/config-loader');
 
 const router = express.Router();
 
+// Load build info once at startup
+let buildInfo = {
+    commit: process.env.BUILD_COMMIT || 'unknown',
+    buildTime: process.env.BUILD_TIME || 'unknown',
+    branch: process.env.BUILD_BRANCH || 'unknown'
+};
+
+// Try to load from build-info.json if it exists
+const buildInfoPath = path.join(__dirname, '..', 'build-info.json');
+try {
+    if (fs.existsSync(buildInfoPath)) {
+        const fileInfo = JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
+        buildInfo = { ...buildInfo, ...fileInfo };
+    }
+} catch (e) {
+    // Ignore errors reading build-info.json
+}
+
+// Middleware to restrict to localhost only
+function localhostOnly(req, res, next) {
+    const ip = req.ip || req.connection.remoteAddress;
+    if (ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1') {
+        next();
+    } else {
+        res.status(403).json({ error: 'Forbidden' });
+    }
+}
+
 router.get('/version', (req, res) => {
     const pkg = require(path.join(__dirname, '..', 'package.json'));
     res.json({ version: pkg.version });
+});
+
+router.get('/health', localhostOnly, (req, res) => {
+    const pkg = require(path.join(__dirname, '..', 'package.json'));
+    res.json({
+        status: 'ok',
+        version: pkg.version,
+        commit: buildInfo.commit,
+        branch: buildInfo.branch,
+        buildTime: buildInfo.buildTime,
+        uptime: process.uptime(),
+        nodeVersion: process.version
+    });
 });
 
 router.get('/flags', (req, res) => {


### PR DESCRIPTION
The MongoDB schema uses camelCase property names (protocol, loadBalancerArn, sslPolicy) but the queries were accessing PascalCase properties (Protocol, LoadBalancerArn, SslPolicy). This caused the detail views to show no data.

Also fixed incorrect property paths in overview.js, teams.js, and tenants.js which were accessing properties at document root level instead of nested inside Configuration.configuration.